### PR TITLE
Fix unhandled errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "diff": "5.0.0",
                 "fuzzaldrin": "2.1.0",
                 "lodash": "4.17.21",
+                "source-map-support": "^0.5.21",
                 "ts-morph": "13.0.2"
             },
             "bin": {
@@ -1507,8 +1508,7 @@
         "node_modules/buffer-from": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-            "dev": true
+            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
         },
         "node_modules/callsites": {
             "version": "3.1.0",
@@ -4492,7 +4492,6 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -4501,7 +4500,6 @@
             "version": "0.5.21",
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
             "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-            "dev": true,
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
@@ -6233,8 +6231,7 @@
         "buffer-from": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-            "dev": true
+            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
         },
         "callsites": {
             "version": "3.1.0",
@@ -8440,14 +8437,12 @@
         "source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "source-map-support": {
             "version": "0.5.21",
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
             "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-            "dev": true,
             "requires": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "diff": "5.0.0",
         "fuzzaldrin": "2.1.0",
         "lodash": "4.17.21",
+        "source-map-support": "^0.5.21",
         "ts-morph": "13.0.2"
     },
     "description": "Code linting/manipulation tools to make your TypeScript code easier to read",
@@ -54,11 +55,11 @@
         "url": "git@github.com:brandongregoryscott/collation.git"
     },
     "scripts": {
-        "build": "npm run esbuild -- --sourcemap --external:commander --external:lodash --external:shelljs --external:ts-morph --external:fuzzaldrin",
+        "build": "npm run esbuild -- --external:commander --external:lodash --external:shelljs --external:ts-morph --external:fuzzaldrin",
         "build:dist": "npm run esbuild -- --minify",
-        "build:watch": "npm run esbuild -- --sourcemap --watch",
+        "build:watch": "npm run esbuild -- --watch",
         "clean": "rimraf dist",
-        "esbuild": "esbuild src/collation.ts --bundle --outfile=dist/collation.js --platform=node --external:ts-morph",
+        "esbuild": "esbuild src/collation.ts --bundle --outfile=dist/collation.js --platform=node --sourcemap --external:ts-morph",
         "prebuild": "npm run clean",
         "prebuild:dist": "npm run clean",
         "prebuild:watch": "npm run clean",

--- a/src/collation.ts
+++ b/src/collation.ts
@@ -8,6 +8,7 @@ import { printProject } from "./cli/handlers/print-project";
 import { runByFile } from "./cli/handlers/run-by-file";
 import { runByFiles } from "./cli/handlers/run-by-files";
 import { ruleRunner } from "./utils/rule-runner";
+import "source-map-support/register";
 
 const main = async () => {
     const program = new Command();

--- a/src/models/context.ts
+++ b/src/models/context.ts
@@ -9,12 +9,16 @@ interface ContextOptions {
 }
 
 class Context {
-    /* @ts-ignore */
     public cliOptions: CliOptions;
-    /* @ts-ignore We're manually handling initialization and don't need TS to hold our hand */
     public project: Project;
 
     private initialized: boolean = false;
+
+    public constructor() {
+        // Set defaults for the sake of testing
+        this.cliOptions = {};
+        this.project = new Project();
+    }
 
     public initialize(context: ContextOptions): Context {
         const { cliOptions, project } = context;

--- a/src/rules/alphabetize-dependency-lists.test.ts
+++ b/src/rules/alphabetize-dependency-lists.test.ts
@@ -97,4 +97,62 @@ describe("alphabetizeDependencyLists", () => {
             expect(result).toMatchSourceFile(expected);
         }
     );
+
+    it("should alphabetize nested property dependencies", async () => {
+        // Arrange
+        const project = new Project({ useInMemoryFileSystem: true });
+        const input = project.createSourceFile(
+            "input.tsx",
+            `
+                const value = useMemo(() => {
+
+                }, [setProject, handleOpenDialog, project.name])
+            `
+        );
+
+        const expected = project.createSourceFile(
+            "expected.tsx",
+            `
+                const value = useMemo(() => {
+
+                }, [handleOpenDialog, project.name, setProject])
+            `
+        );
+
+        // Act
+        const result = await alphabetizeDependencyLists(input);
+
+        // Assert
+        expect(result).toHaveErrors();
+        expect(result).toMatchSourceFile(expected);
+    });
+
+    it("should alphabetize deeply-nested property dependencies", async () => {
+        // Arrange
+        const project = new Project({ useInMemoryFileSystem: true });
+        const input = project.createSourceFile(
+            "input.tsx",
+            `
+                const value = useMemo(() => {
+
+                }, [x, setProject, handleOpenDialog, theme.colors.gray900])
+            `
+        );
+
+        const expected = project.createSourceFile(
+            "expected.tsx",
+            `
+                const value = useMemo(() => {
+
+                }, [handleOpenDialog, setProject, theme.colors.gray900, x])
+            `
+        );
+
+        // Act
+        const result = await alphabetizeDependencyLists(input);
+
+        // Assert
+        expect(result).toHaveErrors();
+        expect(result).toMatchSourceFile(expected);
+    });
 });

--- a/src/rules/alphabetize-jsx-props.test.ts
+++ b/src/rules/alphabetize-jsx-props.test.ts
@@ -1,4 +1,5 @@
 import { Project } from "ts-morph";
+import { Context } from "../models/context";
 import { alphabetizeJsxProps } from "./alphabetize-jsx-props";
 
 describe("alphabetizeJsxProps", () => {
@@ -141,6 +142,43 @@ describe("alphabetizeJsxProps", () => {
         expect(result).toMatchSourceFile(expected);
     });
 
+    it("should leave props unmodified when spread assignment is in beginning of JsxElement and there's only one named prop", async () => {
+        // Arrange
+        const project = new Project({ useInMemoryFileSystem: true });
+        const input = project.createSourceFile(
+            "input.tsx",
+            `
+                const Example = (props) => {
+                    return (
+                        <button
+                            {...buttonProps}
+                            readOnly={false}></button>
+                    );
+                };
+            `
+        );
+
+        const expected = project.createSourceFile(
+            "expected.tsx",
+            `
+                const Example = (props) => {
+                    return (
+                        <button
+                            {...buttonProps}
+                            readOnly={false}></button>
+                    );
+                };
+            `
+        );
+
+        // Act
+        const result = await alphabetizeJsxProps(input);
+
+        // Assert
+        expect(result).not.toHaveErrors();
+        expect(result).toMatchSourceFile(expected);
+    });
+
     it("should sort props when spread assignment is at end of JsxElement", async () => {
         // Arrange
         const project = new Project({ useInMemoryFileSystem: true });
@@ -187,6 +225,43 @@ describe("alphabetizeJsxProps", () => {
 
         // Assert
         expect(result).toHaveErrors();
+        expect(result).toMatchSourceFile(expected);
+    });
+
+    it("should leave props unmodified when spread assignment is at end of JsxElement and there's only one named prop", async () => {
+        // Arrange
+        const project = new Project({ useInMemoryFileSystem: true });
+        const input = project.createSourceFile(
+            "input.tsx",
+            `
+                const Example = (props) => {
+                    return (
+                        <button
+                            readOnly={false}
+                            {...buttonProps}></button>
+                    );
+                };
+            `
+        );
+
+        const expected = project.createSourceFile(
+            "expected.tsx",
+            `
+                const Example = (props) => {
+                    return (
+                        <button
+                            readOnly={false}
+                            {...buttonProps}></button>
+                    );
+                };
+            `
+        );
+
+        // Act
+        const result = await alphabetizeJsxProps(input);
+
+        // Assert
+        expect(result).not.toHaveErrors();
         expect(result).toMatchSourceFile(expected);
     });
 

--- a/src/utils/get-alphabetical-messages.ts
+++ b/src/utils/get-alphabetical-messages.ts
@@ -14,9 +14,9 @@ interface GetHintOptions<TElement, TElementStructure = TElement> {
     /* Sorted collection of elements or their transformed structures */
     sorted: TElementStructure[];
     /* Function to return the element's actual name */
-    getElementName: (element: TElement) => string;
+    getElementName?: (element: TElement) => string;
     /* Function to return the transformed element's actual name */
-    getElementStructureName: (elementStructure: TElementStructure) => string;
+    getElementStructureName?: (elementStructure: TElementStructure) => string;
 }
 
 const getAlphabeticalMessages = <TElement, TElementStructure = TElement>(
@@ -29,8 +29,8 @@ const getAlphabeticalMessages = <TElement, TElementStructure = TElement>(
         elementTypeName,
         original,
         sorted,
-        getElementName,
-        getElementStructureName,
+        getElementName = (element) => element,
+        getElementStructureName = (element) => element,
     } = options;
 
     const propertyName = getElementName(original[index]);

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -6,7 +6,7 @@ import { RuleViolation } from "../models/rule-violation";
 const prefix = chalk.cyanBright("[collation]");
 
 class Logger {
-    public debug(message: string, ...values: any[]): Logger {
+    public debug = (message: string, ...values: any[]): Logger => {
         if (!Context.isVerbose()) {
             return this;
         }
@@ -15,82 +15,82 @@ class Logger {
             `${prefix} ${chalk.gray("DEBUG")} ${message}`,
             ...values
         );
-    }
+    };
 
-    public divider(): Logger {
+    public divider = (): Logger => {
         return this.log(`${prefix} ${"-".repeat(68)}`);
-    }
+    };
 
-    public error(message: string, ...values: any[]): Logger {
+    public error = (message: string, ...values: any[]): Logger => {
         return this.log(
             `${prefix} ${chalk.redBright("ERROR")} ${message}`,
             ...values
         );
-    }
+    };
 
-    public info(message: string, ...values: any[]): Logger {
+    public info = (message: string, ...values: any[]): Logger => {
         return this.log(`${prefix} ${message}`, ...values);
-    }
+    };
 
-    public json(value: any): Logger {
+    public json = (value: any): Logger => {
         return this.log(JSON.stringify(value, undefined, 4));
-    }
+    };
 
-    public newLine(): Logger {
+    public newLine = (): Logger => {
         return this.log("");
-    }
+    };
 
-    public rawLine(message: string, ...values: any[]): Logger {
+    public rawLine = (message: string, ...values: any[]): Logger => {
         return this.log(message, ...values);
-    }
+    };
 
-    public ruleDebug(
+    public ruleDebug = (
         partialViolation: Pick<
             RuleViolation,
             "file" | "lineNumber" | "message" | "rule"
         >
-    ): Logger {
+    ): Logger => {
         return this.debug(this.getRuleMessage(partialViolation));
-    }
+    };
 
-    public ruleViolation(violation: RuleViolation): Logger {
+    public ruleViolation = (violation: RuleViolation): Logger => {
         let baseMessage = this.getRuleMessage(violation);
         if (!isEmpty(violation.hint)) {
             baseMessage = `${baseMessage} ${chalk.gray(`(${violation.hint})`)}`;
         }
 
         return this.error(baseMessage);
-    }
+    };
 
-    public warn(message: string, ...values: any[]): Logger {
+    public warn = (message: string, ...values: any[]): Logger => {
         return this.log(
             `${chalk.yellowBright(`${prefix} WARN`)} ${message}`,
             ...values
         );
-    }
+    };
 
-    private getRuleMessage(
+    private getRuleMessage = (
         partialViolation: Pick<
             RuleViolation,
             "file" | "lineNumber" | "message" | "rule"
         >
-    ): string {
+    ): string => {
         const { file, lineNumber, message } = partialViolation;
         const rule = chalk.magenta(partialViolation.rule);
         const fileName = chalk.bold(file.getBaseName());
         const location = chalk.bold(`${fileName}:${lineNumber}`);
 
         return `${rule} ${location} ${message}`;
-    }
+    };
 
-    private log(message: string, ...values: any[]): Logger {
+    private log = (message: string, ...values: any[]): Logger => {
         if (Context.isSilent()) {
             return this;
         }
 
         console.log(message, ...values);
         return this;
-    }
+    };
 }
 
 const Singleton = new Logger();

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -3,6 +3,10 @@ import { isEmpty } from "lodash";
 import { Context } from "../models/context";
 import { RuleViolation } from "../models/rule-violation";
 
+interface RuleMessageOptions
+    extends Pick<RuleViolation, "file" | "message" | "rule">,
+        Partial<Pick<RuleViolation, "lineNumber">> {}
+
 const prefix = chalk.cyanBright("[collation]");
 
 class Logger {
@@ -45,12 +49,10 @@ class Logger {
     };
 
     public ruleDebug = (
-        partialViolation: Pick<
-            RuleViolation,
-            "file" | "lineNumber" | "message" | "rule"
-        >
+        options: RuleMessageOptions,
+        ...values: any[]
     ): Logger => {
-        return this.debug(this.getRuleMessage(partialViolation));
+        return this.debug(this.getRuleMessage(options), ...values);
     };
 
     public ruleViolation = (violation: RuleViolation): Logger => {
@@ -69,16 +71,15 @@ class Logger {
         );
     };
 
-    private getRuleMessage = (
-        partialViolation: Pick<
-            RuleViolation,
-            "file" | "lineNumber" | "message" | "rule"
-        >
-    ): string => {
-        const { file, lineNumber, message } = partialViolation;
-        const rule = chalk.magenta(partialViolation.rule);
+    private getRuleMessage = (options: RuleMessageOptions): string => {
+        const { file, lineNumber, message } = options;
+        const rule = chalk.magenta(options.rule);
         const fileName = chalk.bold(file.getBaseName());
-        const location = chalk.bold(`${fileName}:${lineNumber}`);
+        let location = chalk.bold(`${fileName}`);
+
+        if (lineNumber != null) {
+            location += chalk.bold(`:${lineNumber}`);
+        }
 
         return `${rule} ${location} ${message}`;
     };


### PR DESCRIPTION
Fixes a few unhandled cases/errors:

- `this` reference in `Logger` throwing an error
    ```sh
      (node:8843) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'getRuleMessage' of undefined
      at ruleViolation (/Users/Brandon/collation/dist/collation.js:8879:28)
      at Array.forEach (<anonymous>)
      at printRuleResult (/Users/Brandon/collation/dist/collation.js:9566:57)
      at Array.forEach (<anonymous>)
      at printRuleResults (/Users/Brandon/collation/dist/collation.js:9565:53)
      at ruleRunner (/Users/Brandon/collation/dist/collation.js:9575:3)
      at async runByFile (/Users/Brandon/collation/dist/collation.js:9597:3)
      at async main (/Users/Brandon/collation/dist/collation.js:9644:5)
    ```
- `alphabetize-dependency-lists` was not handling nested properties (`PropertyAccessExpression` in TS/ts-morph) gracefully, and throwing errors or adding duplicate sub-identifiers
- `alphabetize-jsx-props` was not short-circuiting properly when JsxElements w/ spread operators were already "sorted" (such as having one variable above or below which did not need any further manipulation)
- Added `source-map-support` to better trace unhandled errors in the future