### PR TITLE
Alphabetize enum members

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,7 +4,7 @@
 ALL_CHANGED_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep -e .ts -e .tsx -e .json -e .md | sed 's| |\\ |g')
 TS_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep -e .ts -e .tsx | sed 's| |\\ |g')
 
-[[ ! -z  "$TS_FILES" ]] && npx collation --files $TS_FILES
+[[ ! -z  "$TS_FILES" ]] && ./dist/collation.js --files $TS_FILES
 [[ ! -z  "$ALL_CHANGED_FILES" ]] && npm run format -- $ALL_CHANGED_FILES
 [[ ! -z  "$ALL_CHANGED_FILES" ]] && git add $ALL_CHANGED_FILES
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,23 @@ Current rules:
         // ...business logic here
     }, [handleOpenDialog, isLoading, setProject]);
     ```
+1. `alphabetize-enums`
+    - Alphabetizes members of explicitly defined enums, i.e.
+    ```ts
+    enum Animals {
+        Dog = "dog",
+        Wolf = "wolf",
+        Cat = "cat",
+    }
+    ```
+    will be transformed to:
+    ```ts
+    enum Animals {
+        Cat = "cat",
+        Dog = "dog",
+        Wolf = "wolf",
+    }
+    ```
 1. `alphabetize-interfaces`
     - Alphabetizes properties in an interface, i.e.
     ```ts

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "build:dist": "npm run esbuild -- --minify",
         "build:watch": "npm run esbuild -- --watch",
         "clean": "rimraf dist",
-        "esbuild": "esbuild src/collation.ts --bundle --outfile=dist/collation.js --platform=node --sourcemap --external:ts-morph",
+        "esbuild": "tsc --noEmit && esbuild src/collation.ts --bundle --outfile=dist/collation.js --platform=node --sourcemap --external:ts-morph",
         "format": "prettier --write",
         "prebuild": "npm run clean",
         "prebuild:dist": "npm run clean",

--- a/src/constants/rule-map.ts
+++ b/src/constants/rule-map.ts
@@ -1,11 +1,13 @@
 import { RuleName } from "../enums/rule-name";
 import { alphabetizeDependencyLists } from "../rules/alphabetize-dependency-lists";
+import { alphabetizeEnums } from "../rules/alphabetize-enums";
 import { alphabetizeInterfaces } from "../rules/alphabetize-interfaces";
 import { alphabetizeJsxProps } from "../rules/alphabetize-jsx-props";
 import { RuleFunction } from "../types/rule-function";
 
 const RuleMap: Record<RuleName, RuleFunction> = {
     [RuleName.AlphabetizeDependencyLists]: alphabetizeDependencyLists,
+    [RuleName.AlphabetizeEnums]: alphabetizeEnums,
     [RuleName.AlphabetizeInterfaces]: alphabetizeInterfaces,
     [RuleName.AlphabetizeJsxProps]: alphabetizeJsxProps,
 };

--- a/src/enums/rule-name.ts
+++ b/src/enums/rule-name.ts
@@ -1,5 +1,6 @@
 enum RuleName {
     AlphabetizeDependencyLists = "alphabetize-dependency-lists",
+    AlphabetizeEnums = "alphabetize-enums",
     AlphabetizeInterfaces = "alphabetize-interfaces",
     AlphabetizeJsxProps = "alphabetize-jsx-props",
 }

--- a/src/rules/alphabetize-dependency-lists.test.ts
+++ b/src/rules/alphabetize-dependency-lists.test.ts
@@ -1,4 +1,4 @@
-import { Project } from "ts-morph";
+import { createSourceFile } from "../test/test-utils";
 import { alphabetizeDependencyLists } from "./alphabetize-dependency-lists";
 
 describe("alphabetizeDependencyLists", () => {
@@ -6,9 +6,7 @@ describe("alphabetizeDependencyLists", () => {
         "should alphabetize variables in %p dependency list",
         async (functionName: string) => {
             // Arrange
-            const project = new Project({ useInMemoryFileSystem: true });
-            const input = project.createSourceFile(
-                "input.tsx",
+            const input = createSourceFile(
                 `
                     const value = ${functionName}(() => {
 
@@ -16,8 +14,7 @@ describe("alphabetizeDependencyLists", () => {
                 `
             );
 
-            const expected = project.createSourceFile(
-                "expected.tsx",
+            const expected = createSourceFile(
                 `
                     const value = ${functionName}(() => {
 
@@ -38,9 +35,7 @@ describe("alphabetizeDependencyLists", () => {
         "should not change %p calls that don't have a second argument",
         async (functionName: string) => {
             // Arrange
-            const project = new Project({ useInMemoryFileSystem: true });
-            const input = project.createSourceFile(
-                "input.tsx",
+            const input = createSourceFile(
                 `
                 const value = ${functionName}(() => {
 
@@ -48,8 +43,7 @@ describe("alphabetizeDependencyLists", () => {
             `
             );
 
-            const expected = project.createSourceFile(
-                "expected.tsx",
+            const expected = createSourceFile(
                 `
                     const value = ${functionName}(() => {
 
@@ -70,9 +64,7 @@ describe("alphabetizeDependencyLists", () => {
         "should not change %p calls that don't have an ArrayLiteralExpression as second argument",
         async (functionName: string) => {
             // Arrange
-            const project = new Project({ useInMemoryFileSystem: true });
-            const input = project.createSourceFile(
-                "input.tsx",
+            const input = createSourceFile(
                 `
                     const value = ${functionName}(() => {
 
@@ -80,8 +72,7 @@ describe("alphabetizeDependencyLists", () => {
                 `
             );
 
-            const expected = project.createSourceFile(
-                "expected.tsx",
+            const expected = createSourceFile(
                 `
                     const value = ${functionName}(() => {
 
@@ -100,22 +91,19 @@ describe("alphabetizeDependencyLists", () => {
 
     it("should alphabetize nested property dependencies", async () => {
         // Arrange
-        const project = new Project({ useInMemoryFileSystem: true });
-        const input = project.createSourceFile(
-            "input.tsx",
+        const input = createSourceFile(
             `
                 const value = useMemo(() => {
 
-                }, [setProject, handleOpenDialog, project.name])
+                }, [setProject, handleOpenDialog, name])
             `
         );
 
-        const expected = project.createSourceFile(
-            "expected.tsx",
+        const expected = createSourceFile(
             `
                 const value = useMemo(() => {
 
-                }, [handleOpenDialog, project.name, setProject])
+                }, [handleOpenDialog, name, setProject])
             `
         );
 
@@ -129,9 +117,7 @@ describe("alphabetizeDependencyLists", () => {
 
     it("should alphabetize deeply-nested property dependencies", async () => {
         // Arrange
-        const project = new Project({ useInMemoryFileSystem: true });
-        const input = project.createSourceFile(
-            "input.tsx",
+        const input = createSourceFile(
             `
                 const value = useMemo(() => {
 
@@ -139,8 +125,7 @@ describe("alphabetizeDependencyLists", () => {
             `
         );
 
-        const expected = project.createSourceFile(
-            "expected.tsx",
+        const expected = createSourceFile(
             `
                 const value = useMemo(() => {
 
@@ -158,9 +143,7 @@ describe("alphabetizeDependencyLists", () => {
 
     it("should not return errors when deeply-nested property dependencies are already sorted", async () => {
         // Arrange
-        const project = new Project({ useInMemoryFileSystem: true });
-        const input = project.createSourceFile(
-            "input.tsx",
+        const input = createSourceFile(
             `
                 const value = useMemo(() => {
 
@@ -168,8 +151,7 @@ describe("alphabetizeDependencyLists", () => {
             `
         );
 
-        const expected = project.createSourceFile(
-            "expected.tsx",
+        const expected = createSourceFile(
             `
                 const value = useMemo(() => {
 

--- a/src/rules/alphabetize-dependency-lists.test.ts
+++ b/src/rules/alphabetize-dependency-lists.test.ts
@@ -95,7 +95,7 @@ describe("alphabetizeDependencyLists", () => {
             `
                 const value = useMemo(() => {
 
-                }, [setProject, handleOpenDialog, name])
+                }, [setProject, handleOpenDialog, project.name])
             `
         );
 
@@ -103,7 +103,7 @@ describe("alphabetizeDependencyLists", () => {
             `
                 const value = useMemo(() => {
 
-                }, [handleOpenDialog, name, setProject])
+                }, [handleOpenDialog, project.name, setProject])
             `
         );
 

--- a/src/rules/alphabetize-enums.test.ts
+++ b/src/rules/alphabetize-enums.test.ts
@@ -54,6 +54,36 @@ describe("alphabetizeEnums", () => {
         expect(result).toHaveErrors();
     });
 
+    it("should not modify implicit-numeric enums", async () => {
+        // Arrange
+        const input = createSourceFile(
+            `
+                enum Car {
+                    Make,
+                    Wheels,
+                    Model,
+                }
+            `
+        );
+
+        const expected = createSourceFile(
+            `
+                enum Car {
+                    Make,
+                    Wheels,
+                    Model,
+                }
+            `
+        );
+
+        // Act
+        const result = await alphabetizeEnums(input);
+
+        // Assert
+        expect(result).not.toHaveErrors();
+        expect(result).toMatchSourceFile(expected);
+    });
+
     it("should alphabetize members with multi-line comments", async () => {
         // Arrange
         const input = createSourceFile(

--- a/src/rules/alphabetize-enums.test.ts
+++ b/src/rules/alphabetize-enums.test.ts
@@ -1,0 +1,31 @@
+import { createSourceFile } from "../test/test-utils";
+import { alphabetizeEnums } from "./alphabetize-enums";
+
+describe.only("alphabetizeEnums", () => {
+    it("should alphabetize explicit string-based enums by key", async () => {
+        const input = createSourceFile(
+            `
+                enum Animals {
+                    Dog = "dog",
+                    Wolf = "wolf",
+                    Cat = "cat",
+                }
+            `
+        );
+
+        const expected = createSourceFile(
+            `
+                enum Animals {
+                    Cat = "cat",
+                    Dog = "dog",
+                    Wolf = "wolf",
+                }
+            `
+        );
+
+        const result = await alphabetizeEnums(input);
+
+        expect(result).toMatchSourceFile(expected);
+        expect(result).toHaveErrors();
+    });
+});

--- a/src/rules/alphabetize-enums.test.ts
+++ b/src/rules/alphabetize-enums.test.ts
@@ -28,4 +28,29 @@ describe.only("alphabetizeEnums", () => {
         expect(result).toMatchSourceFile(expected);
         expect(result).toHaveErrors();
     });
+
+    it("should alphabetize explicit number-based enums by key", async () => {
+        const input = createSourceFile(
+            `
+                enum SortOrder {
+                    DESC = 0,
+                    ASC = 1,
+                }
+            `
+        );
+
+        const expected = createSourceFile(
+            `
+                enum SortOrder {
+                    ASC = 1,
+                    DESC = 0,
+                }
+            `
+        );
+
+        const result = await alphabetizeEnums(input);
+
+        expect(result).toMatchSourceFile(expected);
+        expect(result).toHaveErrors();
+    });
 });

--- a/src/rules/alphabetize-enums.test.ts
+++ b/src/rules/alphabetize-enums.test.ts
@@ -1,7 +1,7 @@
 import { createSourceFile } from "../test/test-utils";
 import { alphabetizeEnums } from "./alphabetize-enums";
 
-describe.only("alphabetizeEnums", () => {
+describe("alphabetizeEnums", () => {
     it("should alphabetize explicit string-based enums by key", async () => {
         const input = createSourceFile(
             `
@@ -52,5 +52,77 @@ describe.only("alphabetizeEnums", () => {
 
         expect(result).toMatchSourceFile(expected);
         expect(result).toHaveErrors();
+    });
+
+    it("should alphabetize members with multi-line comments", async () => {
+        // Arrange
+        const input = createSourceFile(
+            `
+                enum Car {
+                    /* Make of the car */
+                    Make = "make",
+                    /* Number of wheels the car has */
+                    Wheels = "wheels",
+                    /* Model of the car */
+                    Model = "model",
+                }
+            `
+        );
+
+        const expected = createSourceFile(
+            `
+                enum Car {
+                    /* Make of the car */
+                    Make = "make",
+                    /* Model of the car */
+                    Model = "model",
+                    /* Number of wheels the car has */
+                    Wheels = "wheels",
+                }
+            `
+        );
+
+        // Act
+        const result = await alphabetizeEnums(input);
+
+        // Assert
+        expect(result).toHaveErrors();
+        expect(result).toMatchSourceFile(expected);
+    });
+
+    it("should alphabetize members with single-line comments", async () => {
+        // Arrange
+        const input = createSourceFile(
+            `
+                enum Car {
+                    // Make of the car
+                    Make = "make",
+                    // Number of wheels the car has
+                    Wheels = "wheels",
+                    // Model of the car
+                    Model = "model",
+                }
+            `
+        );
+
+        const expected = createSourceFile(
+            `
+                enum Car {
+                    // Make of the car
+                    Make = "make",
+                    // Model of the car
+                    Model = "model",
+                    // Number of wheels the car has
+                    Wheels = "wheels",
+                }
+            `
+        );
+
+        // Act
+        const result = await alphabetizeEnums(input);
+
+        // Assert
+        expect(result).toHaveErrors();
+        expect(result).toMatchSourceFile(expected);
     });
 });

--- a/src/rules/alphabetize-enums.ts
+++ b/src/rules/alphabetize-enums.ts
@@ -1,0 +1,11 @@
+import { SourceFile } from "ts-morph";
+import { RuleResult } from "../interfaces/rule-result";
+import { RuleFunction } from "../types/rule-function";
+
+const alphabetizeEnums: RuleFunction = async (
+    file: SourceFile
+): Promise<RuleResult> => {
+    return { errors: [], diff: [], file };
+};
+
+export { alphabetizeEnums };

--- a/src/rules/alphabetize-enums.ts
+++ b/src/rules/alphabetize-enums.ts
@@ -1,11 +1,87 @@
-import { SourceFile } from "ts-morph";
+import { diffLines } from "diff";
+import { compact, flatMap, isEqual, sortBy } from "lodash";
+import { EnumDeclaration, EnumMember, SourceFile } from "ts-morph";
+import { RuleName } from "../enums/rule-name";
 import { RuleResult } from "../interfaces/rule-result";
+import { RuleViolation } from "../models/rule-violation";
 import { RuleFunction } from "../types/rule-function";
+import { getAlphabeticalMessages } from "../utils/get-alphabetical-messages";
+import { Logger } from "../utils/logger";
 
 const alphabetizeEnums: RuleFunction = async (
     file: SourceFile
 ): Promise<RuleResult> => {
-    return { errors: [], diff: [], file };
+    const originalFileContent = file.getText();
+    const enums = file.getEnums();
+    const errors = flatMap(enums, alphabetizeEnum);
+    const endingFileContent = file.getText();
+
+    return {
+        errors,
+        diff: diffLines(originalFileContent, endingFileContent),
+        file,
+    };
 };
+
+const alphabetizeEnum = (_enum: EnumDeclaration): RuleViolation[] => {
+    const members = _enum.getMembers();
+    const name = getEnumName(_enum);
+    if (members.some((member) => !member.hasInitializer())) {
+        Logger.ruleDebug({
+            file: _enum.getSourceFile(),
+            lineNumber: _enum.getStartLineNumber(),
+            message: `Enum ${name} contains member(s) without initializers and can't be alphabetized.`,
+            rule: RuleName.AlphabetizeEnums,
+        });
+        return [];
+    }
+
+    const sorted = sortBy(members, getEnumName) as EnumMember[];
+
+    if (isEqual(members, sorted)) {
+        Logger.ruleDebug({
+            file: _enum.getSourceFile(),
+            lineNumber: _enum.getStartLineNumber(),
+            message: `Members of enum ${name} are already alphabetized.`,
+            rule: RuleName.AlphabetizeEnums,
+        });
+        return [];
+    }
+
+    const deletionQueue: EnumMember[] = [];
+    const errors = sorted.map((member) => {
+        const currentIndex = members.indexOf(member);
+        const expectedIndex = sorted.indexOf(member);
+
+        deletionQueue.push(member);
+        _enum.insertMember(expectedIndex, member.getStructure());
+
+        if (currentIndex === expectedIndex) {
+            return;
+        }
+
+        return new RuleViolation({
+            ...getAlphabeticalMessages({
+                index: currentIndex,
+                expectedIndex,
+                elementTypeName: "member",
+                sorted,
+                original: members,
+                parentName: name,
+                getElementName: getEnumMemberName,
+                getElementStructureName: getEnumMemberName,
+            }),
+            file: member.getSourceFile(),
+            lineNumber: member.getStartLineNumber(),
+            rule: RuleName.AlphabetizeEnums,
+        });
+    });
+
+    deletionQueue.forEach((member) => member.remove());
+    return compact(errors);
+};
+
+const getEnumMemberName = (enumMember: EnumMember) => enumMember.getName();
+const getEnumName = (_enum: EnumDeclaration) => _enum.getName();
 
 export { alphabetizeEnums };

--- a/src/rules/alphabetize-interfaces.test.ts
+++ b/src/rules/alphabetize-interfaces.test.ts
@@ -1,12 +1,11 @@
 import { Project } from "ts-morph";
+import { createSourceFile } from "../test/test-utils";
 import { alphabetizeInterfaces } from "./alphabetize-interfaces";
 
 describe("alphabetizeInterfaces", () => {
     it("should sort properties in interface when there are unsorted properties", async () => {
         // Arrange
-        const project = new Project({ useInMemoryFileSystem: true });
-        const input = project.createSourceFile(
-            "input.ts",
+        const input = createSourceFile(
             `
                 interface Example {
                     zeta?: string;
@@ -17,8 +16,7 @@ describe("alphabetizeInterfaces", () => {
             `
         );
 
-        const expected = project.createSourceFile(
-            "expected.ts",
+        const expected = createSourceFile(
             `
                 interface Example {
                     alpha: number;
@@ -39,9 +37,7 @@ describe("alphabetizeInterfaces", () => {
 
     it("should sort properties in all interfaces when there are multiple unsorted interfaces", async () => {
         // Arrange
-        const project = new Project({ useInMemoryFileSystem: true });
-        const input = project.createSourceFile(
-            "input.ts",
+        const input = createSourceFile(
             `
                 interface Car {
                     make: string;
@@ -56,8 +52,7 @@ describe("alphabetizeInterfaces", () => {
             `
         );
 
-        const expected = project.createSourceFile(
-            "expected.ts",
+        const expected = createSourceFile(
             `
                 interface Car {
                     make: string;
@@ -82,9 +77,7 @@ describe("alphabetizeInterfaces", () => {
 
     it("should sort properties with multi-line comments", async () => {
         // Arrange
-        const project = new Project({ useInMemoryFileSystem: true });
-        const input = project.createSourceFile(
-            "input.ts",
+        const input = createSourceFile(
             `
                 interface Car {
                     /*
@@ -103,8 +96,7 @@ describe("alphabetizeInterfaces", () => {
             `
         );
 
-        const expected = project.createSourceFile(
-            "expected.ts",
+        const expected = createSourceFile(
             `
                 interface Car {
                     /*
@@ -133,9 +125,7 @@ describe("alphabetizeInterfaces", () => {
 
     it("should sort properties with single-line comments", async () => {
         // Arrange
-        const project = new Project({ useInMemoryFileSystem: true });
-        const input = project.createSourceFile(
-            "input.ts",
+        const input = createSourceFile(
             `
                 interface Car {
                     // Make of the car
@@ -148,8 +138,7 @@ describe("alphabetizeInterfaces", () => {
             `
         );
 
-        const expected = project.createSourceFile(
-            "expected.ts",
+        const expected = createSourceFile(
             `
                 interface Car {
                     // Make of the car

--- a/src/rules/alphabetize-interfaces.ts
+++ b/src/rules/alphabetize-interfaces.ts
@@ -17,16 +17,10 @@ import {
 import { RuleName } from "../enums/rule-name";
 import { RuleResult } from "../interfaces/rule-result";
 import { RuleViolation } from "../models/rule-violation";
+import { Comment } from "../types/comment";
 import { RuleFunction } from "../types/rule-function";
 import { getAlphabeticalMessages } from "../utils/get-alphabetical-messages";
 import { Logger } from "../utils/logger";
-
-type CommentNode =
-    | CommentStatement
-    | CommentClassElement
-    | CommentTypeElement
-    | CommentObjectLiteralElement
-    | CommentEnumMember;
 
 type InterfaceMember = Exclude<
     TypeElementTypes,
@@ -36,7 +30,7 @@ type InterfaceMember = Exclude<
 >;
 
 interface PropertyGroup {
-    comment?: CommentNode;
+    comment?: Comment;
     property: InterfaceMember;
 }
 
@@ -58,17 +52,17 @@ const alphabetizeInterfaces: RuleFunction = async (
 const alphabetizeInterface = (
     _interface: InterfaceDeclaration
 ): RuleViolation[] => {
-    const propertyOrCommentNodes = _interface
+    const propertyOrComments = _interface
         .getDescendants()
         .filter(
             (node) =>
                 (Node.hasName(node) && Node.isTypeElement(node)) ||
                 Node.isCommentNode(node)
-        ) as Array<CommentNode | InterfaceMember>;
+        ) as Array<Comment | InterfaceMember>;
 
     const propertyGroups = compact(
-        propertyOrCommentNodes.map((commentOrProperty, index) =>
-            toPropertyGroup(propertyOrCommentNodes, commentOrProperty, index)
+        propertyOrComments.map((commentOrProperty, index) =>
+            toPropertyGroup(propertyOrComments, commentOrProperty, index)
         )
     );
 
@@ -86,7 +80,7 @@ const alphabetizeInterface = (
         return [];
     }
 
-    const deletionQueue: Array<InterfaceMember | CommentNode> = [];
+    const deletionQueue: Array<InterfaceMember | Comment> = [];
 
     let index = 0;
     const errors = sorted.map((propertyGroup) => {
@@ -133,8 +127,8 @@ const getPropertyName = (propertyGroup: PropertyGroup) =>
     propertyGroup.property.getName();
 
 const toPropertyGroup = (
-    propertyOrCommentNodes: Array<InterfaceMember | CommentNode>,
-    commentOrProperty: InterfaceMember | CommentNode,
+    propertyOrCommentNodes: Array<InterfaceMember | Comment>,
+    commentOrProperty: InterfaceMember | Comment,
     index: number
 ): PropertyGroup | undefined => {
     if (Node.isCommentNode(commentOrProperty)) {

--- a/src/rules/alphabetize-jsx-props.test.ts
+++ b/src/rules/alphabetize-jsx-props.test.ts
@@ -1,13 +1,10 @@
-import { Project } from "ts-morph";
-import { Context } from "../models/context";
+import { createSourceFile } from "../test/test-utils";
 import { alphabetizeJsxProps } from "./alphabetize-jsx-props";
 
 describe("alphabetizeJsxProps", () => {
     it("should sort props of each JsxElement when there are unsorted props", async () => {
         // Arrange
-        const project = new Project({ useInMemoryFileSystem: true });
-        const input = project.createSourceFile(
-            "input.tsx",
+        const input = createSourceFile(
             `
                 const Example = (props) => {
                     return (
@@ -21,8 +18,7 @@ describe("alphabetizeJsxProps", () => {
                 };
             `
         );
-        const expected = project.createSourceFile(
-            "expected.tsx",
+        const expected = createSourceFile(
             `
                 const Example = (props) => {
                     return (
@@ -44,9 +40,7 @@ describe("alphabetizeJsxProps", () => {
 
     it("should sort props before and after spread assignment in JsxElement", async () => {
         // Arrange
-        const project = new Project({ useInMemoryFileSystem: true });
-        const input = project.createSourceFile(
-            "input.tsx",
+        const input = createSourceFile(
             `
                 const Example = (props) => {
                     return (
@@ -65,8 +59,7 @@ describe("alphabetizeJsxProps", () => {
             `
         );
 
-        const expected = project.createSourceFile(
-            "expected.tsx",
+        const expected = createSourceFile(
             `
                 const Example = (props) => {
                     return (
@@ -95,9 +88,7 @@ describe("alphabetizeJsxProps", () => {
 
     it("should sort props when spread assignment is in beginning of JsxElement", async () => {
         // Arrange
-        const project = new Project({ useInMemoryFileSystem: true });
-        const input = project.createSourceFile(
-            "input.tsx",
+        const input = createSourceFile(
             `
                 const Example = (props) => {
                     return (
@@ -115,8 +106,7 @@ describe("alphabetizeJsxProps", () => {
             `
         );
 
-        const expected = project.createSourceFile(
-            "expected.tsx",
+        const expected = createSourceFile(
             `
                 const Example = (props) => {
                     return (
@@ -144,9 +134,7 @@ describe("alphabetizeJsxProps", () => {
 
     it("should leave props unmodified when spread assignment is in beginning of JsxElement and there's only one named prop", async () => {
         // Arrange
-        const project = new Project({ useInMemoryFileSystem: true });
-        const input = project.createSourceFile(
-            "input.tsx",
+        const input = createSourceFile(
             `
                 const Example = (props) => {
                     return (
@@ -158,8 +146,7 @@ describe("alphabetizeJsxProps", () => {
             `
         );
 
-        const expected = project.createSourceFile(
-            "expected.tsx",
+        const expected = createSourceFile(
             `
                 const Example = (props) => {
                     return (
@@ -181,9 +168,7 @@ describe("alphabetizeJsxProps", () => {
 
     it("should sort props when spread assignment is at end of JsxElement", async () => {
         // Arrange
-        const project = new Project({ useInMemoryFileSystem: true });
-        const input = project.createSourceFile(
-            "input.tsx",
+        const input = createSourceFile(
             `
                 const Example = (props) => {
                     return (
@@ -201,8 +186,7 @@ describe("alphabetizeJsxProps", () => {
             `
         );
 
-        const expected = project.createSourceFile(
-            "expected.tsx",
+        const expected = createSourceFile(
             `
                 const Example = (props) => {
                     return (
@@ -230,9 +214,7 @@ describe("alphabetizeJsxProps", () => {
 
     it("should leave props unmodified when spread assignment is at end of JsxElement and there's only one named prop", async () => {
         // Arrange
-        const project = new Project({ useInMemoryFileSystem: true });
-        const input = project.createSourceFile(
-            "input.tsx",
+        const input = createSourceFile(
             `
                 const Example = (props) => {
                     return (
@@ -244,8 +226,7 @@ describe("alphabetizeJsxProps", () => {
             `
         );
 
-        const expected = project.createSourceFile(
-            "expected.tsx",
+        const expected = createSourceFile(
             `
                 const Example = (props) => {
                     return (
@@ -267,9 +248,7 @@ describe("alphabetizeJsxProps", () => {
 
     it("should sort props of self-closing JsxElements", async () => {
         // Arrange
-        const project = new Project({ useInMemoryFileSystem: true });
-        const input = project.createSourceFile(
-            "input.tsx",
+        const input = createSourceFile(
             `
                 <EmptyState
                     title="No Instruments Found"
@@ -279,8 +258,7 @@ describe("alphabetizeJsxProps", () => {
             `
         );
 
-        const expected = project.createSourceFile(
-            "expected.tsx",
+        const expected = createSourceFile(
             `
                 <EmptyState
                     description="Save a new instrument to begin"
@@ -300,9 +278,7 @@ describe("alphabetizeJsxProps", () => {
 
     it("should sort props of JsxElements that receive JsxElements as props", async () => {
         // Arrange
-        const project = new Project({ useInMemoryFileSystem: true });
-        const input = project.createSourceFile(
-            "input.tsx",
+        const input = createSourceFile(
             `
                 <Button marginY={8} marginRight={12} iconAfter={<CogIcon size={24} color="gray" />}>
                     Settings
@@ -310,8 +286,7 @@ describe("alphabetizeJsxProps", () => {
             `
         );
 
-        const expected = project.createSourceFile(
-            "expected.tsx",
+        const expected = createSourceFile(
             `
                 <Button iconAfter={<CogIcon color="gray" size={24} />} marginRight={12} marginY={8}>
                     Settings

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -6,7 +6,8 @@ const createInMemoryProject = (): Project =>
 
 const createSourceFile = (content: string): SourceFile =>
     createInMemoryProject().createSourceFile(
-        `${uniqueId("source-file")}.ts`,
+        // Always use .tsx to support JSX whether or not fixture requires it
+        `${uniqueId("source-file")}.tsx`,
         content
     );
 

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -1,0 +1,13 @@
+import { uniqueId } from "lodash";
+import { Project, SourceFile } from "ts-morph";
+
+const createInMemoryProject = (): Project =>
+    new Project({ useInMemoryFileSystem: true });
+
+const createSourceFile = (content: string): SourceFile =>
+    createInMemoryProject().createSourceFile(
+        `${uniqueId("source-file")}.ts`,
+        content
+    );
+
+export { createInMemoryProject, createSourceFile };

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -1,0 +1,16 @@
+import {
+    CommentStatement,
+    CommentClassElement,
+    CommentTypeElement,
+    CommentObjectLiteralElement,
+    CommentEnumMember,
+} from "ts-morph";
+
+type Comment =
+    | CommentStatement
+    | CommentClassElement
+    | CommentTypeElement
+    | CommentObjectLiteralElement
+    | CommentEnumMember;
+
+export type { Comment };


### PR DESCRIPTION
Fixes #1 

Additionally abstracts some test setup for initializing a new `ts-morph` `Project`/`SourceFile`. There's some additional refactoring to that could be done to consolidate some of the "get T node + its Comment" since there's a lot of overlap between `alphabetize-interfaces` and `alphabetize-enums` in this regard, but I'm holding off for now