### PR TITLE
Swap default imports with named in `named-exports-only` rule

### DIFF
--- a/src/rules/named-exports-only.test.ts
+++ b/src/rules/named-exports-only.test.ts
@@ -1,62 +1,155 @@
 import { namedExportsOnly } from "./named-exports-only";
-import { createSourceFile } from "../test/test-utils";
+import {
+    createInMemoryProject,
+    createSourceFile,
+    CreateSourceFileOptions,
+} from "../test/test-utils";
 
 describe("namedExportsOnly", () => {
-    it("should convert default export to named export at end of file", async () => {
-        // Arrange
-        const input = createSourceFile(
-            `
-                const useInput = (options?: UseInputOptions) => {
-                    // ...implementation
-                }
+    describe("default export at end of file", () => {
+        it("should convert named export at end of file", async () => {
+            // Arrange
+            const input = createSourceFile(
+                `
+                    const useInput = (options?: UseInputOptions) => {
+                        // ...implementation
+                    }
 
-                export default useInput;
-            `
-        );
+                    export default useInput;
+                `
+            );
 
-        const expected = createSourceFile(
-            `
-                const useInput = (options?: UseInputOptions) => {
-                    // ...implementation
-                }
+            const expected = createSourceFile(
+                `
+                    const useInput = (options?: UseInputOptions) => {
+                        // ...implementation
+                    }
 
-                export { useInput };
-            `
-        );
+                    export { useInput };
+                `
+            );
 
-        // Act
-        const result = await namedExportsOnly(input);
+            // Act
+            const result = await namedExportsOnly(input);
 
-        // Assert
-        expect(result).toHaveErrors();
-        expect(result).toMatchSourceFile(expected);
-        await result.file.save();
+            // Assert
+            expect(result).toHaveErrors();
+            expect(result).toMatchSourceFile(expected);
+            await result.file.save();
+        });
+
+        it("should convert default imports to named imports in referencing files", async () => {
+            // Arrange
+            // We need to use the same Project instance to get referencing source files
+            const project = createInMemoryProject();
+            const options: CreateSourceFileOptions = {
+                project,
+                // There's currently a bug in ts-morph where references won't be returned in .tsx files
+                extension: ".ts",
+            };
+            const input = createSourceFile(
+                `
+                    const noop = () => {};
+
+                    export default noop;
+                `,
+                options
+            );
+
+            const referencingFile = createSourceFile(
+                `
+                    import noop from "./${input.getBaseNameWithoutExtension()}";
+
+                    noop();
+                `,
+                options
+            );
+
+            const expected = createSourceFile(
+                `
+                    import { noop } from "./${input.getBaseNameWithoutExtension()}";
+
+                    noop();
+                `,
+                options
+            );
+
+            // Act
+            const result = await namedExportsOnly(input);
+
+            // Assert
+            expect(referencingFile).toMatchSourceFile(expected);
+            await result.file.save();
+        });
     });
 
-    it("should convert inline default export to named export", async () => {
-        // Arrange
-        const input = createSourceFile(
-            `
-                export default function useInput(options?: UseInputOptions) {
-                    // ...implementation
-                }
-            `
-        );
+    describe("inline default export", () => {
+        it("should convert to inline named export", async () => {
+            // Arrange
+            const input = createSourceFile(
+                `
+                    export default function useInput(options?: UseInputOptions) {
+                        // ...implementation
+                    }
+                `
+            );
 
-        const expected = createSourceFile(
-            `
-                export function useInput(options?: UseInputOptions) {
-                    // ...implementation
-                }
-            `
-        );
+            const expected = createSourceFile(
+                `
+                    export function useInput(options?: UseInputOptions) {
+                        // ...implementation
+                    }
+                `
+            );
 
-        // Act
-        const result = await namedExportsOnly(input);
+            // Act
+            const result = await namedExportsOnly(input);
 
-        // Assert
-        expect(result).toHaveErrors();
-        expect(result).toMatchSourceFile(expected);
-        await result.file.save();
+            // Assert
+            expect(result).toHaveErrors();
+            expect(result).toMatchSourceFile(expected);
+            await result.file.save();
+        });
+
+        it("should convert default imports to named imports in referencing files", async () => {
+            // Arrange
+            // We need to use the same Project instance to get referencing source files
+            const project = createInMemoryProject();
+            const options: CreateSourceFileOptions = {
+                project,
+                extension: ".ts",
+            };
+            const input = createSourceFile(
+                `
+                    export default function noop() {};
+                `,
+                options
+            );
+
+            const referencingFile = createSourceFile(
+                `
+                    import noop from "./${input.getBaseNameWithoutExtension()}";
+
+                    noop();
+                `,
+                options
+            );
+
+            const expected = createSourceFile(
+                `
+                    import { noop } from "./${input.getBaseNameWithoutExtension()}";
+
+                    noop();
+                `,
+                options
+            );
+
+            // Act
+            const result = await namedExportsOnly(input);
+
+            // Assert
+            expect(referencingFile).toMatchSourceFile(expected);
+            await result.file.save();
+        });
     });
 });

--- a/src/rules/named-exports-only.ts
+++ b/src/rules/named-exports-only.ts
@@ -55,10 +55,7 @@ const convertDefaultExport = (file: SourceFile): RuleViolation[] => {
     const defaultExportName = getDefaultExportIdentifier(defaultExport);
     const errors = [getRuleViolation(file, defaultExport)];
 
-    replaceDefaultImports(
-        file,
-        (defaultExport as any as NameableNode).getName()!
-    );
+    replaceDefaultImports(file, defaultExportName);
 
     defaultExport?.remove();
     file.addExportDeclaration({ namedExports: [defaultExportName] });

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -2,14 +2,32 @@ import { uniqueId } from "lodash";
 import { Project, SourceFile } from "ts-morph";
 import * as tags from "common-tags";
 
+export interface CreateSourceFileOptions {
+    /**
+     * File extension of the `SourceFile`.
+     * @default .tsx
+     */
+    extension?: string;
+    /**
+     * `Project` to create the `SoruceFile` in. If not provided, a new one will be created.
+     */
+    project?: Project;
+}
+
 const createInMemoryProject = (): Project =>
     new Project({ useInMemoryFileSystem: true });
 
-const createSourceFile = (content: string): SourceFile =>
-    createInMemoryProject().createSourceFile(
-        // Always use .tsx to support JSX whether or not fixture requires it
-        `${uniqueId("source-file")}.tsx`,
+const createSourceFile = (
+    content: string,
+    options?: CreateSourceFileOptions
+): SourceFile => {
+    const { project = createInMemoryProject(), extension = ".tsx" } =
+        options ?? {};
+
+    return project.createSourceFile(
+        `${uniqueId("source-file")}${extension}`,
         tags.stripIndent(content)
     );
+};
 
 export { createInMemoryProject, createSourceFile };


### PR DESCRIPTION
Resolves #31

It seems to work on .tsx files in `beets`, but I was running into issues unit testing it this way. The tests are written for `.ts` files but everything should work the same way.