### PR TITLE
Rule: ExportsAtEof

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,4 +11,5 @@ module.exports = {
     restoreMocks: true,
     setupFilesAfterEnv: ["./src/test/setup.ts"],
     testEnvironment: "node",
+    silent: false,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
                 "rimraf": "3.0.2",
                 "ts-jest": "27.1.2",
                 "ts-node": "10.4.0",
-                "typescript": "4.5.4"
+                "typescript": "4.6.3"
             },
             "engines": {
                 "node": ">=14"
@@ -4947,9 +4947,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-            "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+            "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -8901,9 +8901,9 @@
             }
         },
         "typescript": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-            "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+            "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
             "dev": true
         },
         "universalify": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "rimraf": "3.0.2",
         "ts-jest": "27.1.2",
         "ts-node": "10.4.0",
-        "typescript": "4.5.4"
+        "typescript": "4.6.3"
     },
     "engines": {
         "node": ">=14"

--- a/src/constants/rule-map.ts
+++ b/src/constants/rule-map.ts
@@ -5,12 +5,14 @@ import { alphabetizeInterfaces } from "../rules/alphabetize-interfaces";
 import { alphabetizeJsxProps } from "../rules/alphabetize-jsx-props";
 import { RuleFunction } from "../types/rule-function";
 import { namedExportsOnly } from "../rules/named-exports-only";
+import { exportsAtEof } from "../rules/exports-at-eof";
 
 const RuleMap: Record<RuleName, RuleFunction> = {
     [RuleName.AlphabetizeDependencyLists]: alphabetizeDependencyLists,
     [RuleName.AlphabetizeEnums]: alphabetizeEnums,
     [RuleName.AlphabetizeInterfaces]: alphabetizeInterfaces,
     [RuleName.AlphabetizeJsxProps]: alphabetizeJsxProps,
+    [RuleName.ExportsAtEof]: exportsAtEof,
     [RuleName.NamedExportsOnly]: namedExportsOnly,
 };
 

--- a/src/enums/rule-name.ts
+++ b/src/enums/rule-name.ts
@@ -3,6 +3,7 @@ enum RuleName {
     AlphabetizeEnums = "alphabetize-enums",
     AlphabetizeInterfaces = "alphabetize-interfaces",
     AlphabetizeJsxProps = "alphabetize-jsx-props",
+    ExportsAtEof = "exports-at-eof",
     NamedExportsOnly = "named-exports-only",
 }
 

--- a/src/models/context.ts
+++ b/src/models/context.ts
@@ -1,6 +1,7 @@
 import chalk from "chalk";
 import { Project } from "ts-morph";
 import { CliOptions } from "../interfaces/cli-options";
+import { safelySaveChanges } from "../utils/file-utils";
 import { Logger } from "../utils/logger";
 
 interface ContextOptions {
@@ -52,7 +53,7 @@ class Context {
             return;
         }
 
-        await this.project.save();
+        safelySaveChanges(this.project);
     }
 
     private throwIfUninitialized(): Context | never {

--- a/src/models/context.ts
+++ b/src/models/context.ts
@@ -53,7 +53,7 @@ class Context {
             return;
         }
 
-        safelySaveChanges(this.project);
+        await safelySaveChanges(this.project);
     }
 
     private throwIfUninitialized(): Context | never {

--- a/src/models/context.ts
+++ b/src/models/context.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import { Project } from "ts-morph";
 import { CliOptions } from "../interfaces/cli-options";
-import { safelySaveChanges } from "../utils/file-utils";
+import { safelySaveChanges } from "../utils/safely-save-changes";
 import { Logger } from "../utils/logger";
 
 interface ContextOptions {

--- a/src/rules/alphabetize-dependency-lists.ts
+++ b/src/rules/alphabetize-dependency-lists.ts
@@ -45,7 +45,7 @@ const _alphabetizeDependencyLists: RuleFunction = async (
     };
 };
 
-_alphabetizeDependencyLists.__name = RuleName.AlphabetizeDependencyLists;
+_alphabetizeDependencyLists._name = RuleName.AlphabetizeDependencyLists;
 
 const alphabetizeFunctionCallDependencies = (
     functionCall: CallExpression

--- a/src/rules/alphabetize-enums.ts
+++ b/src/rules/alphabetize-enums.ts
@@ -34,7 +34,7 @@ const _alphabetizeEnums: RuleFunction = async (
     };
 };
 
-_alphabetizeEnums.__name = RuleName.AlphabetizeEnums;
+_alphabetizeEnums._name = RuleName.AlphabetizeEnums;
 
 const alphabetizeEnum = (_enum: EnumDeclaration): RuleViolation[] => {
     const members = _enum.getMembers();

--- a/src/rules/alphabetize-interfaces.ts
+++ b/src/rules/alphabetize-interfaces.ts
@@ -54,7 +54,7 @@ const _alphabetizeInterfaces: RuleFunction = async (
     };
 };
 
-_alphabetizeInterfaces.__name = RuleName.AlphabetizeInterfaces;
+_alphabetizeInterfaces._name = RuleName.AlphabetizeInterfaces;
 
 const alphabetizeInterface = (
     interfaceOrType: InterfaceOrType

--- a/src/rules/alphabetize-jsx-props.ts
+++ b/src/rules/alphabetize-jsx-props.ts
@@ -50,7 +50,7 @@ const _alphabetizeJsxProps: RuleFunction = async (
     };
 };
 
-_alphabetizeJsxProps.__name = RuleName.AlphabetizeJsxProps;
+_alphabetizeJsxProps._name = RuleName.AlphabetizeJsxProps;
 
 const alphabetizePropsByJsxElement = (
     jsxElement: JsxElement

--- a/src/rules/exports-at-eof.test.ts
+++ b/src/rules/exports-at-eof.test.ts
@@ -10,29 +10,50 @@ describe("exportsAtEof", () => {
         // Arrange
         const input = createSourceFile(
             `
-                export interface UseInputOptions {
-                    onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
-                    value?: string;
-                }
+                export type AddFunction = (x: number, y: number) => number;
 
-                export const useInput = (options?: UseInputOptions) => {
-                    // ...implementation
-                }
+                export const add: AddFunction = (x: number, y: number) => x + y;
             `
         );
 
         const expected = createSourceFile(
             `
-                interface UseInputOptions {
-                    onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
-                    value?: string;
-                }
+                type AddFunction = (x: number, y: number) => number;
 
-                const useInput = (options?: UseInputOptions) => {
-                    // ...implementation
-                }
+                const add: AddFunction = (x: number, y: number) => x + y;
 
-                export { UseInputOptions, useInput };
+                export { AddFunction, add };
+            `
+        );
+
+        // Act
+        const result = await exportsAtEof(input);
+
+        // Assert
+        expect(result).toMatchSourceFile(expected);
+    });
+
+    it("should move type exports above non-type exports", async () => {
+        // Arrange
+        const input = createSourceFile(
+            `
+                type AddFunction = (x: number, y: number) => number;
+
+                const add: AddFunction = (x: number, y: number) => x + y;
+
+                export { add };
+                export type { AddFunction };
+            `
+        );
+
+        const expected = createSourceFile(
+            `
+                type AddFunction = (x: number, y: number) => number;
+
+                const add: AddFunction = (x: number, y: number) => x + y;
+
+                export type { AddFunction };
+                export { add };
             `
         );
 
@@ -47,31 +68,21 @@ describe("exportsAtEof", () => {
         // Arrange
         const input = createSourceFile(
             `
-                export interface UseInputOptions {
-                    onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
-                    value?: string;
-                }
+                export type AddFunction = (x: number, y: number) => number;
 
-                const useInput = (options?: UseInputOptions) => {
-                    // ...implementation
-                }
+                const add: AddFunction = (x: number, y: number) => x + y;
 
-                export { useInput };
+                export { add };
             `
         );
 
         const expected = createSourceFile(
             `
-                interface UseInputOptions {
-                    onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
-                    value?: string;
-                }
+                type AddFunction = (x: number, y: number) => number;
 
-                const useInput = (options?: UseInputOptions) => {
-                    // ...implementation
-                }
+                const add: AddFunction = (x: number, y: number) => x + y;
 
-                export { useInput, UseInputOptions };
+                export { add, AddFunction };
             `
         );
 
@@ -86,16 +97,11 @@ describe("exportsAtEof", () => {
         // Arrange
         const input = createSourceFile(
             `
-                interface UseInputOptions {
-                    onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
-                    value?: string;
-                }
+                type AddFunction = (x: number, y: number) => number;
 
-                const useInput = (options?: UseInputOptions) => {
-                    // ...implementation
-                }
+                const add: AddFunction = (x: number, y: number) => x + y;
 
-                export { useInput, UseInputOptions };
+                export { add, AddFunction };
             `
         );
 
@@ -214,31 +220,25 @@ describe("exportsAtEof", () => {
             // Arrange
             const input = createSourceFile(
                 `
-                    interface UseInputOptions {
-                        onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
-                        value?: string;
+                    type AddFunction = (x: number, y: number) => number;
+
+                    export default function add(x: number, y: number) {
+                        return x + y;
                     }
 
-                    export default function useInput(options?: UseInputOptions) {
-                        // ...implementation
-                    }
-
-                    export { UseInputOptions };
+                    export { AddFunction };
                 `
             );
 
             const expected = createSourceFile(
                 `
-                    interface UseInputOptions {
-                        onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
-                        value?: string;
+                    type AddFunction = (x: number, y: number) => number;
+
+                    function add(x: number, y: number) {
+                        return x + y;
                     }
 
-                    function useInput(options?: UseInputOptions) {
-                        // ...implementation
-                    }
-
-                    export { UseInputOptions, useInput };
+                    export { AddFunction, add };
                 `
             );
 
@@ -261,29 +261,26 @@ describe("exportsAtEof", () => {
 
             const input = createSourceFile(
                 `
-                    interface UseInputOptions {
-                        onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
-                        value?: string;
+                    type AddFunction = (x: number, y: number) => number;
+
+                    export default function add(x: number, y: number) {
+                        return x + y;
                     }
 
-                    export default function useInput(options?: UseInputOptions) {
-                        // ...implementation
-                    }
-
-                    export { UseInputOptions };
+                    export { AddFunction };
                 `,
                 options
             );
             const referencingSourceFile = createSourceFile(
                 `
-                    import useInput from "./${input.getBaseNameWithoutExtension()}";
+                    import add from "./${input.getBaseNameWithoutExtension()}";
                 `,
                 options
             );
 
             const expected = createSourceFile(
                 `
-                    import { useInput } from "./${input.getBaseNameWithoutExtension()}";
+                    import { add } from "./${input.getBaseNameWithoutExtension()}";
                 `,
                 options
             );
@@ -301,32 +298,22 @@ describe("exportsAtEof", () => {
             // Arrange
             const input = createSourceFile(
                 `
-                    interface UseInputOptions {
-                        onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
-                        value?: string;
-                    }
+                    type AddFunction = (x: number, y: number) => number;
 
-                    export const useInput = (options?: UseInputOptions) => {
-                        // ...implementation
-                    }
+                    export const add: AddFunction = (x: number, y: number) => x + y;
 
-                    export type { UseInputOptions };
+                    export type { AddFunction };
                 `
             );
 
             const expected = createSourceFile(
                 `
-                    interface UseInputOptions {
-                        onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
-                        value?: string;
-                    }
+                    type AddFunction = (x: number, y: number) => number;
 
-                    const useInput = (options?: UseInputOptions) => {
-                        // ...implementation
-                    }
+                    const add: AddFunction = (x: number, y: number) => x + y;
 
-                    export type { UseInputOptions };
-                    export { useInput };
+                    export type { AddFunction };
+                    export { add };
                 `
             );
 
@@ -373,31 +360,21 @@ describe("exportsAtEof", () => {
                 });
                 const input = createSourceFile(
                     `
-                        export interface UseInputOptions {
-                            onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
-                            value?: string;
-                        }
+                        export type AddFunction = (x: number, y: number) => number;
 
-                        export const useInput = (options?: UseInputOptions) => {
-                            // ...implementation
-                        }
+                        export const add: AddFunction = (x: number, y: number) => x + y;
                     `,
                     { project }
                 );
 
                 const expected = createSourceFile(
                     `
-                        interface UseInputOptions {
-                            onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
-                            value?: string;
-                        }
+                        type AddFunction = (x: number, y: number) => number;
 
-                        const useInput = (options?: UseInputOptions) => {
-                            // ...implementation
-                        }
+                        const add: AddFunction = (x: number, y: number) => x + y;
 
-                        export type { UseInputOptions };
-                        export { useInput };
+                        export type { AddFunction };
+                        export { add };
                     `,
                     { project }
                 );
@@ -416,33 +393,23 @@ describe("exportsAtEof", () => {
                 });
                 const input = createSourceFile(
                     `
-                        export interface UseInputOptions {
-                            onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
-                            value?: string;
-                        }
+                        export type AddFunction = (x: number, y: number) => number;
 
-                        const useInput = (options?: UseInputOptions) => {
-                            // ...implementation
-                        }
+                        const add: AddFunction = (x: number, y: number) => x + y;
 
-                        export { useInput };
+                        export { add };
                     `,
                     { project }
                 );
 
                 const expected = createSourceFile(
                     `
-                        interface UseInputOptions {
-                            onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
-                            value?: string;
-                        }
+                        type AddFunction = (x: number, y: number) => number;
 
-                        const useInput = (options?: UseInputOptions) => {
-                            // ...implementation
-                        }
+                        const add: AddFunction = (x: number, y: number) => x + y;
 
-                        export type { UseInputOptions };
-                        export { useInput };
+                        export type { AddFunction };
+                        export { add };
                     `,
                     { project }
                 );
@@ -462,37 +429,26 @@ describe("exportsAtEof", () => {
 
                 const input = createSourceFile(
                     `
-                        type Example = string | number;
+                        type AddFunction = (x: number, y: number) => number;
+                        export type SubtractFunction = (x: number, y: number) => number;
 
-                        export interface UseInputOptions {
-                            onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
-                            value?: string;
-                        }
+                        const add: AddFunction = (x: number, y: number) => x + y;
 
-                        export const useInput = (options?: UseInputOptions) => {
-                            // ...implementation
-                        }
-
-                        export type { Example };
+                        export type { AddFunction };
+                        export { add };
                     `,
                     { project }
                 );
 
                 const expected = createSourceFile(
                     `
-                        type Example = string | number;
+                        type AddFunction = (x: number, y: number) => number;
+                        type SubtractFunction = (x: number, y: number) => number;
 
-                        interface UseInputOptions {
-                            onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
-                            value?: string;
-                        }
+                        const add: AddFunction = (x: number, y: number) => x + y;
 
-                        const useInput = (options?: UseInputOptions) => {
-                            // ...implementation
-                        }
-
-                        export type { Example, UseInputOptions };
-                        export { useInput };
+                        export type { AddFunction, SubtractFunction };
+                        export { add };
                     `,
                     { project }
                 );

--- a/src/rules/exports-at-eof.test.ts
+++ b/src/rules/exports-at-eof.test.ts
@@ -31,6 +31,7 @@ describe("exportsAtEof", () => {
 
         // Assert
         expect(result).toMatchSourceFile(expected);
+        expect(result).toHaveErrors();
     });
 
     it("should move type exports above non-type exports", async () => {
@@ -62,6 +63,7 @@ describe("exportsAtEof", () => {
 
         // Assert
         expect(result).toMatchSourceFile(expected);
+        expect(result).toHaveErrors();
     });
 
     it("should update existing export when there is one", async () => {
@@ -91,6 +93,7 @@ describe("exportsAtEof", () => {
 
         // Assert
         expect(result).toMatchSourceFile(expected);
+        expect(result).toHaveErrors();
     });
 
     it("should not return errors when exports are already at end of file", async () => {
@@ -109,8 +112,8 @@ describe("exportsAtEof", () => {
         const result = await exportsAtEof(input);
 
         // Assert
-        expect(result).not.toHaveErrors();
         expect(result).toMatchSourceFile(input);
+        expect(result).not.toHaveErrors();
     });
 
     it("should move existing named exports to end of file when they appear before", async () => {
@@ -142,8 +145,10 @@ describe("exportsAtEof", () => {
         // Act
         const result = await exportsAtEof(input);
 
+        console.log(result.file.getFullText());
         // Assert
         expect(result).toMatchSourceFile(expected);
+        expect(result).toHaveErrors();
     });
 
     it("should consolidate non-type exports when multiple statements exist", async () => {
@@ -247,6 +252,7 @@ describe("exportsAtEof", () => {
 
             // Assert
             expect(result).toMatchSourceFile(expected);
+            expect(result).toHaveErrors();
         });
 
         it("should update referencing SourceFiles to use named import", async () => {
@@ -322,6 +328,7 @@ describe("exportsAtEof", () => {
 
             // Assert
             expect(result).toMatchSourceFile(expected);
+            expect(result).toHaveErrors();
         });
 
         it("should consolidate type exports when multiple statements exist", async () => {
@@ -384,6 +391,7 @@ describe("exportsAtEof", () => {
 
                 // Assert
                 expect(result).toMatchSourceFile(expected);
+                expect(result).toHaveErrors();
             });
 
             it("should create separate type export when existing non-type export exists", async () => {
@@ -419,6 +427,7 @@ describe("exportsAtEof", () => {
 
                 // Assert
                 expect(result).toMatchSourceFile(expected);
+                expect(result).toHaveErrors();
             });
 
             it("should update existing type export", async () => {
@@ -458,6 +467,7 @@ describe("exportsAtEof", () => {
 
                 // Assert
                 expect(result).toMatchSourceFile(expected);
+                expect(result).toHaveErrors();
             });
         });
     });

--- a/src/rules/exports-at-eof.test.ts
+++ b/src/rules/exports-at-eof.test.ts
@@ -109,6 +109,71 @@ describe("exportsAtEof", () => {
         expect(result).toMatchSourceFile(input);
     });
 
+    it("should move existing named exports to end of file when they appear before", async () => {
+        // Arrange
+        const input = createSourceFile(
+            `
+                const add = (x: number, y: number) => x + y;
+
+                const subtract = (x: number, y: number) => x - y;
+
+                export { add, subtract };
+
+                const multiply = (x: number, y: number) => x * y;
+            `
+        );
+
+        const expected = createSourceFile(
+            `
+                const add = (x: number, y: number) => x + y;
+
+                const subtract = (x: number, y: number) => x - y;
+
+                const multiply = (x: number, y: number) => x * y;
+
+                export { add, subtract };
+            `
+        );
+
+        // Act
+        const result = await exportsAtEof(input);
+
+        // Assert
+        expect(result).toHaveErrors();
+        expect(result).toMatchSourceFile(expected);
+    });
+
+    it("should consolidate exports when multiple statements exist", async () => {
+        // Arrange
+        const input = createSourceFile(
+            `
+                const add = (x: number, y: number) => x + y;
+
+                const subtract = (x: number, y: number) => x - y;
+
+                export { add };
+                export { subtract };
+            `
+        );
+
+        const expected = createSourceFile(
+            `
+                const add = (x: number, y: number) => x + y;
+
+                const subtract = (x: number, y: number) => x - y;
+
+                export { add, subtract };
+            `
+        );
+
+        // Act
+        const result = await exportsAtEof(input);
+
+        // Assert
+        expect(result).toHaveErrors();
+        expect(result).toMatchSourceFile(expected);
+    });
+
     describe("default exports", () => {
         it("should convert default exports to named exports", async () => {
             // Arrange

--- a/src/rules/exports-at-eof.test.ts
+++ b/src/rules/exports-at-eof.test.ts
@@ -84,6 +84,31 @@ describe("exportsAtEof", () => {
         expect(result).toMatchSourceFile(expected);
     });
 
+    it("should not return errors when exports are already at end of file", async () => {
+        // Arrange
+        const input = createSourceFile(
+            `
+                interface UseInputOptions {
+                    onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+                    value?: string;
+                }
+
+                const useInput = (options?: UseInputOptions) => {
+                    // ...implementation
+                }
+
+                export { useInput, UseInputOptions };
+            `
+        );
+
+        // Act
+        const result = await exportsAtEof(input);
+
+        // Assert
+        expect(result).not.toHaveErrors();
+        expect(result).toMatchSourceFile(input);
+    });
+
     describe("default exports", () => {
         it("should convert default exports to named exports", async () => {
             // Arrange
@@ -216,4 +241,5 @@ describe("exportsAtEof", () => {
     });
 });
 
+export {};
 export {};

--- a/src/rules/exports-at-eof.test.ts
+++ b/src/rules/exports-at-eof.test.ts
@@ -39,4 +39,44 @@ describe("exportsAtEof", () => {
         expect(result).toHaveErrors();
         expect(result).toMatchSourceFile(expected);
     });
+
+    it("should update existing export when there is one", async () => {
+        // Arrange
+        const input = createSourceFile(
+            `
+                export interface UseInputOptions {
+                    onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+                    value?: string;
+                }
+
+                const useInput = (options?: UseInputOptions) => {
+                    // ...implementation
+                }
+
+                export { useInput };
+            `
+        );
+
+        const expected = createSourceFile(
+            `
+                interface UseInputOptions {
+                    onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+                    value?: string;
+                }
+
+                const useInput = (options?: UseInputOptions) => {
+                    // ...implementation
+                }
+
+                export { useInput, UseInputOptions };
+            `
+        );
+
+        // Act
+        const result = await exportsAtEof(input);
+
+        // Assert
+        expect(result).toHaveErrors();
+        expect(result).toMatchSourceFile(expected);
+    });
 });

--- a/src/rules/exports-at-eof.test.ts
+++ b/src/rules/exports-at-eof.test.ts
@@ -40,7 +40,6 @@ describe("exportsAtEof", () => {
         const result = await exportsAtEof(input);
 
         // Assert
-        expect(result).toHaveErrors();
         expect(result).toMatchSourceFile(expected);
     });
 
@@ -80,7 +79,6 @@ describe("exportsAtEof", () => {
         const result = await exportsAtEof(input);
 
         // Assert
-        expect(result).toHaveErrors();
         expect(result).toMatchSourceFile(expected);
     });
 
@@ -190,7 +188,6 @@ describe("exportsAtEof", () => {
             `
         );
 
-        // Unsure why the code is adding additional whitespace, but ignore it for now
         const expected = createSourceFile(
             `
                 type AddFunction = (x: number, y: number) => number;
@@ -201,7 +198,7 @@ describe("exportsAtEof", () => {
                 const subtract: SubtractFunction = (x: number, y: number) => x - y;
 
                 export type { AddFunction, SubtractFunction };
-                export {     add, subtract };
+                export { add, subtract };
             `
         );
 
@@ -249,7 +246,6 @@ describe("exportsAtEof", () => {
             const result = await exportsAtEof(input);
 
             // Assert
-            expect(result).toHaveErrors();
             expect(result).toMatchSourceFile(expected);
         });
 
@@ -329,7 +325,8 @@ describe("exportsAtEof", () => {
                         // ...implementation
                     }
 
-                    export { UseInputOptions, useInput };
+                    export type { UseInputOptions };
+                    export { useInput };
                 `
             );
 
@@ -337,7 +334,6 @@ describe("exportsAtEof", () => {
             const result = await exportsAtEof(input);
 
             // Assert
-            expect(result).toHaveErrors();
             expect(result).toMatchSourceFile(expected);
         });
 
@@ -410,7 +406,6 @@ describe("exportsAtEof", () => {
                 const result = await exportsAtEof(input);
 
                 // Assert
-                expect(result).toHaveErrors();
                 expect(result).toMatchSourceFile(expected);
             });
 
@@ -456,7 +451,6 @@ describe("exportsAtEof", () => {
                 const result = await exportsAtEof(input);
 
                 // Assert
-                expect(result).toHaveErrors();
                 expect(result).toMatchSourceFile(expected);
             });
 
@@ -507,7 +501,6 @@ describe("exportsAtEof", () => {
                 const result = await exportsAtEof(input);
 
                 // Assert
-                expect(result).toHaveErrors();
                 expect(result).toMatchSourceFile(expected);
             });
         });

--- a/src/rules/exports-at-eof.test.ts
+++ b/src/rules/exports-at-eof.test.ts
@@ -171,4 +171,49 @@ describe("exportsAtEof", () => {
             expect(referencingSourceFile).toMatchSourceFile(expected);
         });
     });
+
+    describe("type only exports", () => {
+        it("should not attach non-type exports to type export", async () => {
+            // Arrange
+            const input = createSourceFile(
+                `
+                interface UseInputOptions {
+                    onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+                    value?: string;
+                }
+
+                export const useInput = (options?: UseInputOptions) => {
+                    // ...implementation
+                }
+
+                export type { UseInputOptions };
+            `
+            );
+
+            const expected = createSourceFile(
+                `
+                interface UseInputOptions {
+                    onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+                    value?: string;
+                }
+
+                const useInput = (options?: UseInputOptions) => {
+                    // ...implementation
+                }
+
+                export type { UseInputOptions };
+                export { useInput }
+            `
+            );
+
+            // Act
+            const result = await exportsAtEof(input);
+
+            // Assert
+            expect(result).toHaveErrors();
+            expect(result).toMatchSourceFile(expected);
+        });
+    });
 });
+
+export {};

--- a/src/rules/exports-at-eof.test.ts
+++ b/src/rules/exports-at-eof.test.ts
@@ -1,0 +1,42 @@
+import { exportsAtEof } from "./exports-at-eof";
+import { createSourceFile } from "../test/test-utils";
+
+describe("exportsAtEof", () => {
+    it("should move in-line exports to end of file", async () => {
+        // Arrange
+        const input = createSourceFile(
+            `
+                export interface UseInputOptions {
+                    onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+                    value?: string;
+                }
+
+                export const useInput = (options?: UseInputOptions) => {
+                    // ...implementation
+                }
+            `
+        );
+
+        const expected = createSourceFile(
+            `
+                interface UseInputOptions {
+                    onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+                    value?: string;
+                }
+
+                const useInput = (options?: UseInputOptions) => {
+                    // ...implementation
+                }
+
+                export { UseInputOptions, useInput };
+            `
+        );
+
+        // Act
+        const result = await exportsAtEof(input);
+
+        // Assert
+        expect(result).toHaveErrors();
+        expect(result).toMatchSourceFile(expected);
+    });
+});

--- a/src/rules/exports-at-eof.test.ts
+++ b/src/rules/exports-at-eof.test.ts
@@ -239,5 +239,3 @@ describe("exportsAtEof", () => {
         });
     });
 });
-
-export {};

--- a/src/rules/exports-at-eof.test.ts
+++ b/src/rules/exports-at-eof.test.ts
@@ -202,33 +202,32 @@ describe("exportsAtEof", () => {
             // Arrange
             const input = createSourceFile(
                 `
-                interface UseInputOptions {
-                    onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
-                    value?: string;
-                }
+                    interface UseInputOptions {
+                        onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+                        value?: string;
+                    }
 
-                export const useInput = (options?: UseInputOptions) => {
-                    // ...implementation
-                }
+                    export const useInput = (options?: UseInputOptions) => {
+                        // ...implementation
+                    }
 
-                export type { UseInputOptions };
-            `
+                    export type { UseInputOptions };
+                `
             );
 
             const expected = createSourceFile(
                 `
-                interface UseInputOptions {
-                    onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
-                    value?: string;
-                }
+                    interface UseInputOptions {
+                        onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+                        value?: string;
+                    }
 
-                const useInput = (options?: UseInputOptions) => {
-                    // ...implementation
-                }
+                    const useInput = (options?: UseInputOptions) => {
+                        // ...implementation
+                    }
 
-                export type { UseInputOptions };
-                export { useInput }
-            `
+                    export { UseInputOptions, useInput };
+                `
             );
 
             // Act
@@ -241,5 +240,4 @@ describe("exportsAtEof", () => {
     });
 });
 
-export {};
 export {};

--- a/src/rules/exports-at-eof.ts
+++ b/src/rules/exports-at-eof.ts
@@ -7,6 +7,7 @@ import { Logger } from "../utils/logger";
 import { ExportDeclaration, ExportSpecifier, Node, SourceFile } from "ts-morph";
 import { castArray, flatMap, intersection, isEmpty, uniq } from "lodash";
 import { withRetry } from "../utils/with-retry";
+import { replaceDefaultImports } from "../utils/import-utils";
 
 const _exportsAtEof: RuleFunction = async (
     file: SourceFile
@@ -69,6 +70,10 @@ const moveExportsToEof = (file: SourceFile): RuleViolation[] => {
                     exportedDeclaration
                 );
                 return;
+            }
+
+            if (exportedNode.isDefaultExport()) {
+                replaceDefaultImports(file, name!);
             }
 
             exportedNode.setIsExported(false);

--- a/src/rules/exports-at-eof.ts
+++ b/src/rules/exports-at-eof.ts
@@ -26,14 +26,14 @@ const _exportsAtEof: RuleFunction = async (
     file: SourceFile
 ): Promise<RuleResult> => {
     const originalFileContent = file.getText();
-    const errors = removeInlineExports(file);
+    const inlineExportErrors = removeInlineExports(file);
     mergeExportDeclarationsByFile(file);
-    moveExportsToEofByFile(file);
+    const outOfOrderExportErrors = moveExportsToEofByFile(file);
 
     const endingFileContent = file.getText();
 
     return {
-        errors,
+        errors: [...inlineExportErrors, ...outOfOrderExportErrors],
         diff: diffLines(originalFileContent, endingFileContent),
         file,
     };

--- a/src/rules/exports-at-eof.ts
+++ b/src/rules/exports-at-eof.ts
@@ -3,39 +3,32 @@ import { RuleName } from "../enums/rule-name";
 import { RuleResult } from "../interfaces/rule-result";
 import { RuleViolation } from "../models/rule-violation";
 import { RuleFunction } from "../types/rule-function";
-import { Logger } from "../utils/logger";
-import { ExportedDeclarations, NameableNode, Node, SourceFile } from "ts-morph";
-import { compact, flatMap, isEmpty, last, takeRight, trim, uniq } from "lodash";
+import { SourceFile } from "ts-morph";
+import { compact, difference, isEmpty } from "lodash";
 import { withRetry } from "../utils/with-retry";
-import { replaceDefaultImports } from "../utils/import-utils";
 import {
     asExportedNode,
     getExportedDeclarations,
 } from "../utils/exported-declarations-utils";
 import {
-    getExportNames,
-    moveExportsToEof as _moveExportsToEof,
     mergeExportDeclarationsByFile,
+    moveExportsToEofByFile,
 } from "../utils/export-declaration-utils";
-import { ExportedNode } from "../types/exported-node";
-
-interface Export {
-    isType: boolean;
-    name: string;
-}
-
-interface MoveExportDeclarationsToEofResult {
-    error: RuleViolation;
-    export: Export;
-}
+import {
+    getExportedNodeName,
+    toNamedExportStructure,
+} from "../utils/exported-node-utils";
+import { NamedExportStructure } from "../types/named-export-structure";
+import { replaceDefaultImports } from "../utils/import-utils";
 
 const _exportsAtEof: RuleFunction = async (
     file: SourceFile
 ): Promise<RuleResult> => {
     const originalFileContent = file.getText();
-    _moveExportsToEof(file);
+    const errors = removeInlineExports(file);
     mergeExportDeclarationsByFile(file);
-    const errors = moveExportsToEof(file);
+    moveExportsToEofByFile(file);
+
     const endingFileContent = file.getText();
 
     return {
@@ -47,117 +40,65 @@ const _exportsAtEof: RuleFunction = async (
 
 _exportsAtEof._name = RuleName.ExportsAtEof;
 
-const isEndOfFileExport = (
-    file: SourceFile,
-    exportedNode: ExportedNode
-): boolean => {
-    if (!Node.hasName(exportedNode as Node)) {
-        return false;
+const getExportStructureName = (exportStructure: NamedExportStructure) =>
+    exportStructure.name;
+
+const removeInlineExports = (file: SourceFile): RuleViolation[] => {
+    const exportedDeclarations = getExportedDeclarations(file);
+    const inlineExportedNodes = compact(
+        exportedDeclarations.map(asExportedNode)
+    );
+
+    if (isEmpty(inlineExportedNodes)) {
+        return [];
     }
 
-    // Take the last 2 statements to allow for named export line + type exports, if they exist
-    const lastStatements = takeRight(file.getStatements(), 2).filter(
-        Node.isExportDeclaration
+    const exportStructures = compact(
+        inlineExportedNodes.map(toNamedExportStructure)
     );
 
-    const exportNames = getExportNames(lastStatements);
-    return exportNames.includes(
-        (exportedNode as any as NameableNode).getName()!
-    );
-};
-
-const moveExportsToEof = (file: SourceFile): RuleViolation[] => {
-    const results = compact(
-        flatMap(getExportedDeclarations(file), moveExportedDeclarationsToEof)
-    );
-
-    const errors = results.map((result) => result.error);
-    const exports = results.map((result) => result.export);
-
-    if (isEmpty(exports)) {
-        if (!isEmpty(errors)) {
-            Logger.debug(
-                "Exports collection was empty but errors were not",
-                exports,
-                errors
-            );
+    inlineExportedNodes.forEach((exportedNode) => {
+        const name = getExportedNodeName(exportedNode);
+        if (exportedNode.isDefaultExport() && name != null) {
+            replaceDefaultImports(file, name);
         }
-        return errors;
-    }
 
-    const exportDeclarations = file.getExportDeclarations();
-
-    // Attempt to attach the exports to the last declaration, if one exists
-    const exportDeclaration = last(exportDeclarations);
-
-    if (exportDeclaration == null) {
-        file.addExportDeclaration({
-            namedExports: uniq(exports.map((_export) => _export.name)).map(
-                trim
-            ),
-        });
-
-        return errors;
-    }
-
-    const existingExports = getExportNames(exportDeclaration);
-    exportDeclaration.set({
-        namedExports: uniq([
-            ...existingExports,
-            ...exports.map((_export) => _export.name),
-        ]).map(trim),
-        // Take away type keyword if any of the exports are non-type exports - and leave it as-is if not
-        isTypeOnly: exports.some((_export) => !_export.isType)
-            ? false
-            : exportDeclaration.isTypeOnly(),
+        exportedNode.setIsExported(false);
     });
 
-    return errors;
-};
+    const { isolatedModules = false } = file.getProject().getCompilerOptions();
 
-const moveExportedDeclarationsToEof = (
-    exportedDeclaration: ExportedDeclarations
-): MoveExportDeclarationsToEofResult | undefined => {
-    const file = exportedDeclaration.getSourceFile();
-    const exportedNode = asExportedNode(exportedDeclaration);
-    if (exportedNode == null) {
-        return;
-    }
+    const typeExportStructures = exportStructures.filter(
+        (exportStructure) => exportStructure.isType
+    );
 
-    if (isEndOfFileExport(file, exportedNode)) {
-        return;
-    }
-
-    const name = (exportedDeclaration as NameableNode).getName();
-
-    if (isEmpty(name)) {
-        Logger.warn(
-            "Node returned from getExportedDeclarations() doesn't have a name to export",
-            exportedDeclaration
+    if (isolatedModules && !isEmpty(typeExportStructures)) {
+        const nonTypeExportStructures = difference(
+            exportStructures,
+            typeExportStructures
         );
-        return;
+
+        file.addExportDeclaration({
+            namedExports: typeExportStructures.map(getExportStructureName),
+            isTypeOnly: true,
+        });
+
+        if (!isEmpty(nonTypeExportStructures)) {
+            file.addExportDeclaration({
+                namedExports: nonTypeExportStructures.map(
+                    getExportStructureName
+                ),
+                isTypeOnly: false,
+            });
+        }
+        return [];
     }
 
-    if (exportedNode.isDefaultExport()) {
-        replaceDefaultImports(file, name!);
-    }
+    file.addExportDeclaration({
+        namedExports: exportStructures.map(getExportStructureName),
+    });
 
-    exportedNode.setIsExported(false);
-
-    return {
-        export: {
-            name: name!,
-            isType:
-                Node.isInterfaceDeclaration(exportedNode) ||
-                Node.isTypeAliasDeclaration(exportedNode),
-        },
-        error: new RuleViolation({
-            message: `Expected exported node '${name}' to appear at the end of the file.`,
-            lineNumber: exportedNode.getStartLineNumber(),
-            file,
-            rule: RuleName.ExportsAtEof,
-        }),
-    };
+    return [];
 };
 
 const exportsAtEof = withRetry(_exportsAtEof);

--- a/src/rules/exports-at-eof.ts
+++ b/src/rules/exports-at-eof.ts
@@ -1,0 +1,80 @@
+import { diffLines } from "diff";
+import { RuleName } from "../enums/rule-name";
+import { RuleResult } from "../interfaces/rule-result";
+import { RuleViolation } from "../models/rule-violation";
+import { RuleFunction } from "../types/rule-function";
+import { Logger } from "../utils/logger";
+import {
+    ExportedDeclarations,
+    Node,
+    SourceFile,
+    SyntaxKind,
+    VariableStatement,
+} from "ts-morph";
+import { flatMap, isEmpty } from "lodash";
+
+const exportsAtEof: RuleFunction = async (
+    file: SourceFile
+): Promise<RuleResult> => {
+    const originalFileContent = file.getText();
+    const errors = moveExportsToEof(file);
+    const endingFileContent = file.getText();
+
+    return {
+        errors,
+        diff: diffLines(originalFileContent, endingFileContent),
+        file,
+    };
+};
+
+exportsAtEof._name = RuleName.ExportsAtEof;
+
+const moveExportsToEof = (file: SourceFile): RuleViolation[] => {
+    const errors: RuleViolation[] = [];
+    const exports: string[] = [];
+    const exportMap = file.getExportedDeclarations();
+
+    exportMap.forEach((exportedDeclarations) => {
+        exportedDeclarations.forEach((exportedDeclaration) => {
+            if (
+                !Node.isExportable(exportedDeclaration) &&
+                !Node.isVariableDeclaration(exportedDeclaration)
+            ) {
+                return;
+            }
+
+            const exportedNode = Node.isVariableDeclaration(exportedDeclaration)
+                ? exportedDeclaration.getVariableStatement()
+                : exportedDeclaration;
+
+            if (exportedNode == null) {
+                Logger.warn(
+                    `Found VariableDeclaration without a VariableStatement to remove the export keyword from.`,
+                    exportedDeclaration.getFullText()
+                );
+                return;
+            }
+
+            const name = exportedDeclaration.getName();
+
+            if (isEmpty(name)) {
+                Logger.warn(
+                    "Node returned from getExportedDeclarations() doesn't have a name to export",
+                    exportedDeclaration
+                );
+                return;
+            }
+
+            exportedNode.setIsExported(false);
+            exports.push(name!);
+        });
+    });
+
+    file.addExportDeclaration({
+        namedExports: exports,
+    });
+
+    return errors;
+};
+
+export { exportsAtEof };

--- a/src/rules/exports-at-eof.ts
+++ b/src/rules/exports-at-eof.ts
@@ -32,8 +32,8 @@ interface Export {
 }
 
 interface MoveExportDeclarationsToEofResult {
-    export: Export;
     error: RuleViolation;
+    export: Export;
 }
 
 const _exportsAtEof: RuleFunction = async (

--- a/src/rules/exports-at-eof.ts
+++ b/src/rules/exports-at-eof.ts
@@ -7,19 +7,33 @@ import { Logger } from "../utils/logger";
 import {
     ExportableNode,
     ExportDeclaration,
+    ExportedDeclarations,
     ExportSpecifier,
     NameableNode,
     Node,
     SourceFile,
     VariableDeclaration,
 } from "ts-morph";
-import { castArray, flatMap, isEmpty, last, takeRight, uniq } from "lodash";
+import {
+    castArray,
+    compact,
+    flatMap,
+    isEmpty,
+    last,
+    takeRight,
+    uniq,
+} from "lodash";
 import { withRetry } from "../utils/with-retry";
 import { replaceDefaultImports } from "../utils/import-utils";
 
 interface Export {
     isType: boolean;
     name: string;
+}
+
+interface MoveExportDeclarationsToEofResult {
+    export: Export;
+    error: RuleViolation;
 }
 
 const _exportsAtEof: RuleFunction = async (
@@ -49,67 +63,42 @@ const getNamedExports = (
             )
     );
 
-const moveExportsToEof = (file: SourceFile): RuleViolation[] => {
-    const errors: RuleViolation[] = [];
-    const exports: Export[] = [];
+const getExportedDeclarations = (file: SourceFile): ExportedDeclarations[] => {
     const exportMap = file.getExportedDeclarations();
-
+    const aggregatedExportedDeclarations: ExportedDeclarations[] = [];
     exportMap.forEach((exportedDeclarations) => {
-        exportedDeclarations.forEach((exportedDeclaration) => {
-            if (
-                !Node.isExportable(exportedDeclaration) &&
-                !Node.isVariableDeclaration(exportedDeclaration)
-            ) {
-                return;
-            }
-
-            if (isEndOfFileExport(file, exportedDeclaration)) {
-                return;
-            }
-
-            const exportedNode = Node.isVariableDeclaration(exportedDeclaration)
-                ? exportedDeclaration.getVariableStatement()
-                : exportedDeclaration;
-
-            if (exportedNode == null) {
-                Logger.warn(
-                    `Found VariableDeclaration without a VariableStatement to remove the export keyword from.`,
-                    exportedDeclaration.getFullText()
-                );
-                return;
-            }
-
-            const name = exportedDeclaration.getName();
-
-            if (isEmpty(name)) {
-                Logger.warn(
-                    "Node returned from getExportedDeclarations() doesn't have a name to export",
-                    exportedDeclaration
-                );
-                return;
-            }
-
-            if (exportedNode.isDefaultExport()) {
-                replaceDefaultImports(file, name!);
-            }
-
-            exportedNode.setIsExported(false);
-            exports.push({
-                name: name!,
-                isType:
-                    Node.isInterfaceDeclaration(exportedNode) ||
-                    Node.isTypeAliasDeclaration(exportedNode),
-            });
-            errors.push(
-                new RuleViolation({
-                    message: `Expected exported node '${name}' to appear at the end of the file.`,
-                    lineNumber: exportedNode.getStartLineNumber(),
-                    file,
-                    rule: RuleName.ExportsAtEof,
-                })
-            );
-        });
+        aggregatedExportedDeclarations.push(...exportedDeclarations);
     });
+
+    return aggregatedExportedDeclarations;
+};
+
+const isEndOfFileExport = (
+    file: SourceFile,
+    exportedNode: ExportableNode | VariableDeclaration
+): boolean => {
+    if (!Node.hasName(exportedNode as Node)) {
+        return false;
+    }
+
+    // Take the last 2 statements to allow for named export line + type exports, if they exist
+    const lastStatements = takeRight(file.getStatements(), 2).filter(
+        Node.isExportDeclaration
+    );
+
+    const exportNames = getNamedExports(lastStatements);
+    return exportNames.includes(
+        (exportedNode as any as NameableNode).getName()!
+    );
+};
+
+const moveExportsToEof = (file: SourceFile): RuleViolation[] => {
+    const results = compact(
+        flatMap(getExportedDeclarations(file), moveExportedDeclarationsToEof)
+    );
+
+    const errors = results.map((result) => result.error);
+    const exports = results.map((result) => result.export);
 
     if (isEmpty(exports)) {
         if (!isEmpty(errors)) {
@@ -127,11 +116,6 @@ const moveExportsToEof = (file: SourceFile): RuleViolation[] => {
     // Attempt to attach the exports to the last declaration, if one exists
     const exportDeclaration = last(exportDeclarations);
 
-    file.addVariableStatement({
-        declarations: [
-            { name: "test", initializer: "{ size: 123 name: 'abc' }" },
-        ],
-    });
     if (exportDeclaration == null) {
         file.addExportDeclaration({
             namedExports: uniq(exports.map((_export) => _export.name)),
@@ -155,30 +139,64 @@ const moveExportsToEof = (file: SourceFile): RuleViolation[] => {
     return errors;
 };
 
-const isEndOfFileExport = (
-    file: SourceFile,
-    exportedNode: ExportableNode | VariableDeclaration
-): boolean => {
-    if (!Node.hasName(exportedNode as Node)) {
-        return false;
-    }
-
-    const lastStatements = takeRight(file.getStatements(), 2);
+const moveExportedDeclarationsToEof = (
+    exportedDeclaration: ExportedDeclarations
+): MoveExportDeclarationsToEofResult | undefined => {
+    const file = exportedDeclaration.getSourceFile();
 
     if (
-        lastStatements.every(
-            (statement) => !Node.isExportDeclaration(statement)
-        )
+        !Node.isExportable(exportedDeclaration) &&
+        !Node.isVariableDeclaration(exportedDeclaration)
     ) {
-        return false;
+        return;
     }
 
-    const exportNames = getNamedExports(
-        lastStatements.filter(Node.isExportDeclaration)
-    );
-    return exportNames.includes(
-        (exportedNode as any as NameableNode).getName()!
-    );
+    if (isEndOfFileExport(file, exportedDeclaration)) {
+        return;
+    }
+
+    const exportedNode = Node.isVariableDeclaration(exportedDeclaration)
+        ? exportedDeclaration.getVariableStatement()
+        : exportedDeclaration;
+
+    if (exportedNode == null) {
+        Logger.warn(
+            "Found VariableDeclaration without a VariableStatement to remove the export keyword from.",
+            exportedDeclaration.getFullText()
+        );
+        return;
+    }
+
+    const name = exportedDeclaration.getName();
+
+    if (isEmpty(name)) {
+        Logger.warn(
+            "Node returned from getExportedDeclarations() doesn't have a name to export",
+            exportedDeclaration
+        );
+        return;
+    }
+
+    if (exportedNode.isDefaultExport()) {
+        replaceDefaultImports(file, name!);
+    }
+
+    exportedNode.setIsExported(false);
+
+    return {
+        export: {
+            name: name!,
+            isType:
+                Node.isInterfaceDeclaration(exportedNode) ||
+                Node.isTypeAliasDeclaration(exportedNode),
+        },
+        error: new RuleViolation({
+            message: `Expected exported node '${name}' to appear at the end of the file.`,
+            lineNumber: exportedNode.getStartLineNumber(),
+            file,
+            rule: RuleName.ExportsAtEof,
+        }),
+    };
 };
 
 const exportsAtEof = withRetry(_exportsAtEof);

--- a/src/rules/exports-at-eof.ts
+++ b/src/rules/exports-at-eof.ts
@@ -4,16 +4,11 @@ import { RuleResult } from "../interfaces/rule-result";
 import { RuleViolation } from "../models/rule-violation";
 import { RuleFunction } from "../types/rule-function";
 import { Logger } from "../utils/logger";
-import {
-    ExportedDeclarations,
-    Node,
-    SourceFile,
-    SyntaxKind,
-    VariableStatement,
-} from "ts-morph";
-import { flatMap, isEmpty } from "lodash";
+import { Node, SourceFile } from "ts-morph";
+import { isEmpty } from "lodash";
+import { withRetry } from "../utils/with-retry";
 
-const exportsAtEof: RuleFunction = async (
+const _exportsAtEof: RuleFunction = async (
     file: SourceFile
 ): Promise<RuleResult> => {
     const originalFileContent = file.getText();
@@ -27,7 +22,7 @@ const exportsAtEof: RuleFunction = async (
     };
 };
 
-exportsAtEof._name = RuleName.ExportsAtEof;
+_exportsAtEof._name = RuleName.ExportsAtEof;
 
 const moveExportsToEof = (file: SourceFile): RuleViolation[] => {
     const errors: RuleViolation[] = [];
@@ -76,5 +71,7 @@ const moveExportsToEof = (file: SourceFile): RuleViolation[] => {
 
     return errors;
 };
+
+const exportsAtEof = withRetry(_exportsAtEof);
 
 export { exportsAtEof };

--- a/src/rules/named-exports-only.ts
+++ b/src/rules/named-exports-only.ts
@@ -44,7 +44,7 @@ const _namedExportsOnly: RuleFunction = async (
     };
 };
 
-_namedExportsOnly.__name = RuleName.NamedExportsOnly;
+_namedExportsOnly._name = RuleName.NamedExportsOnly;
 
 const convertDefaultExport = (file: SourceFile): RuleViolation[] => {
     const defaultExport = file

--- a/src/rules/named-exports-only.ts
+++ b/src/rules/named-exports-only.ts
@@ -15,6 +15,7 @@ import {
 } from "ts-morph";
 import { compact } from "lodash";
 import { withRetry } from "../utils/with-retry";
+import { replaceDefaultImports } from "../utils/import-utils";
 
 type NameableExportableNode = NameableNode & ExportableNode;
 
@@ -101,24 +102,6 @@ const getDefaultExportIdentifier = (
     return _export.getName() ?? "";
 };
 
-const getDefaultImportDeclarationsForFile = (
-    sourceFile: SourceFile,
-    referencingFiles: SourceFile[]
-): ImportDeclaration[] => {
-    const defaultImports = referencingFiles.map((referencingFile) =>
-        referencingFile
-            .getImportDeclarations()
-            .find(
-                (importDeclaration) =>
-                    importDeclaration.getDefaultImport() != null &&
-                    importDeclaration.getModuleSpecifierSourceFile() ===
-                        sourceFile
-            )
-    );
-
-    return compact(defaultImports);
-};
-
 const getRuleViolation = (
     file: SourceFile,
     _export: ExportAssignment | NameableExportableNode
@@ -133,34 +116,6 @@ const getRuleViolation = (
         lineNumber,
         hint: `'${name}' should be a named export instead`,
         rule: RuleName.NamedExportsOnly,
-    });
-};
-
-const replaceDefaultImports = (file: SourceFile, importName: string) => {
-    const referencingSourceFiles = file.getReferencingSourceFiles();
-    const defaultImports = getDefaultImportDeclarationsForFile(
-        file,
-        referencingSourceFiles
-    );
-
-    defaultImports.forEach((importDeclaration) =>
-        replaceDefaultImport(importName, importDeclaration)
-    );
-};
-
-const replaceDefaultImport = (
-    importName: string,
-    importDeclaration: ImportDeclaration
-) => {
-    const existingNamedImports = importDeclaration
-        .getNamedImports()
-        .map((importSpecifier: ImportSpecifier) =>
-            importSpecifier.getStructure()
-        );
-
-    importDeclaration.set({
-        defaultImport: undefined,
-        namedImports: [importName, ...existingNamedImports],
     });
 };
 

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -1,21 +1,22 @@
 import { uniqueId } from "lodash";
-import { Project, SourceFile } from "ts-morph";
+import { Project, ProjectOptions, SourceFile } from "ts-morph";
 import * as tags from "common-tags";
 
-export interface CreateSourceFileOptions {
+interface CreateSourceFileOptions {
     /**
      * File extension of the `SourceFile`.
      * @default .tsx
      */
     extension?: string;
     /**
-     * `Project` to create the `SoruceFile` in. If not provided, a new one will be created.
+     * `Project` to create the `SourceFile` in. If not provided, a new one will be created.
      */
     project?: Project;
 }
 
-const createInMemoryProject = (): Project =>
-    new Project({ useInMemoryFileSystem: true });
+const createInMemoryProject = (
+    options?: Exclude<ProjectOptions, "useInMemoryFileSystem">
+): Project => new Project({ useInMemoryFileSystem: true, ...(options ?? {}) });
 
 const createSourceFile = (
     content: string,
@@ -30,4 +31,4 @@ const createSourceFile = (
     );
 };
 
-export { createInMemoryProject, createSourceFile };
+export { createInMemoryProject, createSourceFile, CreateSourceFileOptions };

--- a/src/types/exported-node.ts
+++ b/src/types/exported-node.ts
@@ -1,0 +1,15 @@
+import {
+    ExportableNode,
+    ModifierableNode,
+    Node,
+    VariableStatement,
+} from "ts-morph";
+
+type ExportedNode =
+    | (ExportableNode &
+          // ExportableNodeExtensionType is an internal ts-morph type alias for Node & ModifierableNode
+          Node &
+          ModifierableNode)
+    | VariableStatement;
+
+export type { ExportedNode };

--- a/src/types/named-export-structure.ts
+++ b/src/types/named-export-structure.ts
@@ -1,0 +1,6 @@
+interface NamedExportStructure {
+    isType: boolean;
+    name: string;
+}
+
+export { NamedExportStructure };

--- a/src/types/rule-function.ts
+++ b/src/types/rule-function.ts
@@ -3,7 +3,7 @@ import { RuleName } from "../enums/rule-name";
 import { RuleResult } from "../interfaces/rule-result";
 
 type RuleFunction = ((file: SourceFile) => Promise<RuleResult>) & {
-    __name: RuleName;
+    _name: RuleName;
 };
 
 export { RuleFunction };

--- a/src/utils/collection-utils.ts
+++ b/src/utils/collection-utils.ts
@@ -1,0 +1,9 @@
+const countBy = <T>(
+    collection: T[],
+    comparator: (item: T) => boolean
+): number => collection.filter(comparator).length;
+
+const filterNot = <T>(collection: T[], comparator: (item: T) => boolean) =>
+    collection.filter((item) => !comparator(item));
+
+export { countBy, filterNot };

--- a/src/utils/export-declaration-utils.test.ts
+++ b/src/utils/export-declaration-utils.test.ts
@@ -1,0 +1,16 @@
+import { getExportNames } from "./export-declaration-utils";
+
+describe("ExportDeclarationUtils", () => {
+    describe(getExportNames.name, () => {
+        it.todo("should return empty array when input is empty", () => {});
+
+        it.todo("should return export names", () => {});
+
+        describe("when input is not an array", () => {
+            it.todo(
+                "should return export name in single-element array",
+                () => {}
+            );
+        });
+    });
+});

--- a/src/utils/export-declaration-utils.test.ts
+++ b/src/utils/export-declaration-utils.test.ts
@@ -2,15 +2,12 @@ import { getExportNames } from "./export-declaration-utils";
 
 describe("ExportDeclarationUtils", () => {
     describe(getExportNames.name, () => {
-        it.todo("should return empty array when input is empty", () => {});
+        it.todo("should return empty array when input is empty");
 
-        it.todo("should return export names", () => {});
+        it.todo("should return export names");
 
         describe("when input is not an array", () => {
-            it.todo(
-                "should return export name in single-element array",
-                () => {}
-            );
+            it.todo("should return export name in single-element array");
         });
     });
 });

--- a/src/utils/export-declaration-utils.ts
+++ b/src/utils/export-declaration-utils.ts
@@ -147,27 +147,24 @@ const mergeExportDeclarationsByFile = (file: SourceFile): void => {
         (exportDeclaration) => exportDeclaration.hasNamedExports()
     );
 
-    const typeExportCount = countBy(
+    const typeExports = exportDeclarations.filter(isTypeExportDeclaration);
+    const nonTypeExports = filterNot(
         exportDeclarations,
         isTypeExportDeclaration
     );
-    const nonTypeExportCount = exportDeclarations.length - typeExportCount;
+
+    const { length: typeExportCount } = typeExports;
+    const { length: nonTypeExportCount } = nonTypeExports;
 
     if (typeExportCount <= 1 && nonTypeExportCount <= 1) {
         return;
     }
 
     if (typeExportCount > 1) {
-        const typeExports = exportDeclarations.filter(isTypeExportDeclaration);
         mergeExportDeclarations(file, typeExports);
     }
 
     if (nonTypeExportCount > 1) {
-        const nonTypeExports = filterNot(
-            exportDeclarations,
-            isTypeExportDeclaration
-        );
-
         mergeExportDeclarations(file, nonTypeExports);
     }
 };

--- a/src/utils/export-declaration-utils.ts
+++ b/src/utils/export-declaration-utils.ts
@@ -115,15 +115,18 @@ const getInlineExportDeclarations = (file: SourceFile): ExportDeclaration[] =>
 const getEofRuleViolation = (
     file: SourceFile,
     structure: ExportDeclarationStructureWithLineNumber
-): RuleViolation =>
-    new RuleViolation({
+): RuleViolation => {
+    const exportSpecifiers = getExportSpecifierStructures(structure)
+        .map((exportSpecifier) => exportSpecifier.name)
+        .join(", ");
+
+    return new RuleViolation({
         file,
-        message: `Expected export of '${getExportSpecifierStructures(
-            structure
-        ).join(", ")}' to appear at the end of the file.`,
+        message: `Expected export of '${exportSpecifiers}' to appear at the end of the file.`,
         lineNumber: structure.lineNumber,
         rule: RuleName.ExportsAtEof,
     });
+};
 
 const hasDuplicateExportSpecifiers = (
     left:

--- a/src/utils/export-declaration-utils.ts
+++ b/src/utils/export-declaration-utils.ts
@@ -134,6 +134,9 @@ const hasDuplicateExportSpecifiers = (
         | Array<OptionalKind<ExportSpecifierStructure>>
 ): boolean => !isEmpty(getDuplicateExportSpecifiers(left, right));
 
+const hasNamedExport = (file: SourceFile, exportName: string): boolean =>
+    getExportNames(getExportDeclarations(file)).includes(exportName);
+
 const isDuplicateExportSpecifier = (
     exportSpecifier: OptionalKind<ExportSpecifierStructure>,
     exportSpecifiers: Array<OptionalKind<ExportSpecifierStructure>>
@@ -315,6 +318,7 @@ export {
     getEofExportDeclarations,
     getExportDeclarations,
     getExportNames,
+    hasNamedExport,
     isEofExportDeclaration,
     mergeExportDeclarationsByFile,
     moveExportsToEofByFile,

--- a/src/utils/export-declaration-utils.ts
+++ b/src/utils/export-declaration-utils.ts
@@ -1,5 +1,12 @@
 import { castArray, flatMap } from "lodash";
-import { ExportDeclaration, ExportSpecifier } from "ts-morph";
+import { ExportDeclaration, ExportSpecifier, Node, SourceFile } from "ts-morph";
+import { countBy, filterNot } from "./collection-utils";
+
+const isTypeExportDeclaration = (exportDeclaration: ExportDeclaration) =>
+    exportDeclaration.isTypeOnly();
+
+const getExportDeclarations = (file: SourceFile): ExportDeclaration[] =>
+    file.getStatements().filter(Node.isExportDeclaration);
 
 const getExportNames = (
     exportDeclarations: ExportDeclaration[] | ExportDeclaration
@@ -12,4 +19,75 @@ const getExportNames = (
             )
     );
 
-export { getExportNames };
+const mergeExportDeclarations = (
+    file: SourceFile,
+    exportDeclarations: ExportDeclaration[]
+) => {
+    const exportNames = getExportNames(exportDeclarations);
+    const isTypeOnly = exportDeclarations.some(isTypeExportDeclaration);
+    removeExportDeclarations(exportDeclarations);
+
+    file.addExportDeclaration({
+        namedExports: exportNames,
+        isTypeOnly,
+    });
+};
+
+const mergeExportDeclarationsByFile = (file: SourceFile): void => {
+    const exportDeclarations = getExportDeclarations(file).filter(
+        (exportDeclaration) => exportDeclaration.hasNamedExports()
+    );
+
+    const typeExportCount = countBy(
+        exportDeclarations,
+        isTypeExportDeclaration
+    );
+    const nonTypeExportCount = exportDeclarations.length - typeExportCount;
+
+    if (typeExportCount <= 1 && nonTypeExportCount <= 1) {
+        return;
+    }
+
+    if (typeExportCount > 1) {
+        const typeExports = exportDeclarations.filter(isTypeExportDeclaration);
+        mergeExportDeclarations(file, typeExports);
+    }
+
+    if (nonTypeExportCount > 1) {
+        const nonTypeExports = filterNot(
+            exportDeclarations,
+            isTypeExportDeclaration
+        );
+
+        mergeExportDeclarations(file, nonTypeExports);
+    }
+};
+
+/**
+ * Removes and re-adds `ExportDeclaration` statements at the end of a `SourceFile`
+ */
+const moveExportsToEof = (file: SourceFile): void => {
+    const exportDeclarations = getExportDeclarations(file);
+
+    const structures = exportDeclarations.map((exportDeclaration) =>
+        exportDeclaration.getStructure()
+    );
+
+    removeExportDeclarations(exportDeclarations);
+
+    file.addExportDeclarations(structures);
+};
+
+const removeExportDeclarations = (
+    exportDeclarations: ExportDeclaration | ExportDeclaration[]
+) =>
+    castArray(exportDeclarations).forEach((exportDeclaration) =>
+        exportDeclaration.remove()
+    );
+
+export {
+    getExportDeclarations,
+    getExportNames,
+    mergeExportDeclarationsByFile,
+    moveExportsToEof,
+};

--- a/src/utils/export-declaration-utils.ts
+++ b/src/utils/export-declaration-utils.ts
@@ -1,0 +1,15 @@
+import { castArray, flatMap } from "lodash";
+import { ExportDeclaration, ExportSpecifier } from "ts-morph";
+
+const getExportNames = (
+    exportDeclarations: ExportDeclaration[] | ExportDeclaration
+): string[] =>
+    flatMap(castArray(exportDeclarations), (exportDeclaration) =>
+        exportDeclaration
+            .getNamedExports()
+            .map((exportSpecifier: ExportSpecifier) =>
+                exportSpecifier.getName()
+            )
+    );
+
+export { getExportNames };

--- a/src/utils/export-declaration-utils.ts
+++ b/src/utils/export-declaration-utils.ts
@@ -5,13 +5,10 @@ import {
     first,
     flatMap,
     flatten,
-    intersection,
     intersectionBy,
     isEmpty,
     takeRight,
     uniq,
-    uniqBy,
-    uniqWith,
 } from "lodash";
 import {
     ExportDeclaration,
@@ -22,7 +19,7 @@ import {
     OptionalKind,
     SourceFile,
 } from "ts-morph";
-import { countBy, filterNot } from "./collection-utils";
+import { filterNot } from "./collection-utils";
 
 const dedupeExportDeclarationStructuresByName = (
     structures: ExportDeclarationStructure[]

--- a/src/utils/export-declaration-utils.ts
+++ b/src/utils/export-declaration-utils.ts
@@ -1,9 +1,78 @@
-import { castArray, flatMap } from "lodash";
-import { ExportDeclaration, ExportSpecifier, Node, SourceFile } from "ts-morph";
+import {
+    castArray,
+    compact,
+    difference,
+    first,
+    flatMap,
+    flatten,
+    intersection,
+    intersectionBy,
+    isEmpty,
+    takeRight,
+    uniq,
+    uniqBy,
+    uniqWith,
+} from "lodash";
+import {
+    ExportDeclaration,
+    ExportDeclarationStructure,
+    ExportSpecifier,
+    ExportSpecifierStructure,
+    Node,
+    OptionalKind,
+    SourceFile,
+} from "ts-morph";
 import { countBy, filterNot } from "./collection-utils";
 
-const isTypeExportDeclaration = (exportDeclaration: ExportDeclaration) =>
-    exportDeclaration.isTypeOnly();
+const dedupeExportDeclarationStructuresByName = (
+    structures: ExportDeclarationStructure[]
+): ExportDeclarationStructure[] => {
+    const typeExportSpecifiers = flatten(
+        structures
+            .filter(isTypeExportDeclaration)
+            .map(getExportSpecifierStructures)
+    );
+    const nonTypeExportSpecifiers = flatten(
+        filterNot(structures, isTypeExportDeclaration).map(
+            getExportSpecifierStructures
+        )
+    );
+
+    const duplicateExportSpecifiers = getDuplicateExportSpecifiers(
+        typeExportSpecifiers,
+        nonTypeExportSpecifiers
+    );
+
+    if (isEmpty(duplicateExportSpecifiers)) {
+        return structures;
+    }
+
+    return compact(
+        structures.map((structure) =>
+            removeDuplicateExportSpecifiers(
+                structure,
+                duplicateExportSpecifiers
+            )
+        )
+    );
+};
+
+const getDuplicateExportSpecifiers = (
+    left:
+        | OptionalKind<ExportSpecifierStructure>
+        | Array<OptionalKind<ExportSpecifierStructure>>,
+    right:
+        | OptionalKind<ExportSpecifierStructure>
+        | Array<OptionalKind<ExportSpecifierStructure>>
+): Array<OptionalKind<ExportSpecifierStructure>> =>
+    intersectionBy(
+        castArray(left),
+        castArray(right),
+        (exportSpecifier) => exportSpecifier.name
+    );
+
+const getEofExportDeclarations = (file: SourceFile): ExportDeclaration[] =>
+    takeRight(file.getStatements(), 2).filter(Node.isExportDeclaration);
 
 const getExportDeclarations = (file: SourceFile): ExportDeclaration[] =>
     file.getStatements().filter(Node.isExportDeclaration);
@@ -11,13 +80,53 @@ const getExportDeclarations = (file: SourceFile): ExportDeclaration[] =>
 const getExportNames = (
     exportDeclarations: ExportDeclaration[] | ExportDeclaration
 ): string[] =>
-    flatMap(castArray(exportDeclarations), (exportDeclaration) =>
-        exportDeclaration
-            .getNamedExports()
-            .map((exportSpecifier: ExportSpecifier) =>
-                exportSpecifier.getName()
-            )
+    uniq(
+        flatMap(castArray(exportDeclarations), (exportDeclaration) =>
+            exportDeclaration
+                .getNamedExports()
+                .map((exportSpecifier: ExportSpecifier) =>
+                    exportSpecifier.getName()
+                )
+        )
     );
+
+const getExportSpecifierStructures = (
+    structure: ExportDeclarationStructure
+): Array<OptionalKind<ExportSpecifierStructure>> =>
+    (structure.namedExports ?? []) as Array<
+        OptionalKind<ExportSpecifierStructure>
+    >;
+
+const getInlineExportDeclarations = (file: SourceFile): ExportDeclaration[] =>
+    difference(getExportDeclarations(file), getEofExportDeclarations(file));
+
+const hasDuplicateExportSpecifiers = (
+    left:
+        | OptionalKind<ExportSpecifierStructure>
+        | Array<OptionalKind<ExportSpecifierStructure>>,
+    right:
+        | OptionalKind<ExportSpecifierStructure>
+        | Array<OptionalKind<ExportSpecifierStructure>>
+): boolean => !isEmpty(getDuplicateExportSpecifiers(left, right));
+
+const isDuplicateExportSpecifier = (
+    exportSpecifier: OptionalKind<ExportSpecifierStructure>,
+    exportSpecifiers: Array<OptionalKind<ExportSpecifierStructure>>
+) => hasDuplicateExportSpecifiers(exportSpecifier, exportSpecifiers);
+
+const isEofExportDeclaration = (
+    exportDeclaration: ExportDeclaration
+): boolean =>
+    getEofExportDeclarations(exportDeclaration.getSourceFile()).includes(
+        exportDeclaration
+    );
+
+const isTypeExportDeclaration = (
+    exportDeclaration: ExportDeclaration | ExportDeclarationStructure
+): boolean =>
+    exportDeclaration instanceof ExportDeclaration
+        ? exportDeclaration.isTypeOnly()
+        : exportDeclaration.isTypeOnly === true;
 
 const mergeExportDeclarations = (
     file: SourceFile,
@@ -66,16 +175,78 @@ const mergeExportDeclarationsByFile = (file: SourceFile): void => {
 /**
  * Removes and re-adds `ExportDeclaration` statements at the end of a `SourceFile`
  */
-const moveExportsToEof = (file: SourceFile): void => {
-    const exportDeclarations = getExportDeclarations(file);
+const moveExportsToEof = (exportDeclarations: ExportDeclaration[]): void => {
+    const file = first(exportDeclarations)?.getSourceFile();
+    if (file == null) {
+        return;
+    }
 
-    const structures = exportDeclarations.map((exportDeclaration) =>
-        exportDeclaration.getStructure()
+    const structures = dedupeExportDeclarationStructuresByName(
+        exportDeclarations.map((exportDeclaration) =>
+            exportDeclaration.getStructure()
+        )
+    );
+
+    const typeExportStructures = structures.filter(isTypeExportDeclaration);
+    const nonTypeExportStructures = difference(
+        structures,
+        typeExportStructures
     );
 
     removeExportDeclarations(exportDeclarations);
 
-    file.addExportDeclarations(structures);
+    if (isEmpty(typeExportStructures)) {
+        file.addExportDeclarations(structures);
+        return;
+    }
+
+    // Always add type exports above non-type exports
+    file.addExportDeclarations([
+        ...typeExportStructures,
+        ...nonTypeExportStructures,
+    ]);
+};
+
+/**
+ * Removes and re-adds `ExportDeclaration` statements at the end of a `SourceFile`
+ */
+const moveExportsToEofByFile = (file: SourceFile): void => {
+    const exportDeclarations = getExportDeclarations(file);
+    moveExportsToEof(exportDeclarations);
+};
+
+/**
+ * Removes duplicate `ExportSpecifier`s in the `namedExports` collection. If no specifiers remain,
+ * the structure is not returned since it has no use.
+ */
+const removeDuplicateExportSpecifiers = (
+    structure: ExportDeclarationStructure,
+    duplicateExportSpecifiers: Array<OptionalKind<ExportSpecifierStructure>>
+): ExportDeclarationStructure | undefined => {
+    // As a first pass we're more concerned about removing duplicate type exports from non-type export structures
+    if (structure.isTypeOnly) {
+        return structure;
+    }
+
+    const exportSpecifiers = getExportSpecifierStructures(structure);
+    const hasDuplicates = hasDuplicateExportSpecifiers(
+        exportSpecifiers,
+        duplicateExportSpecifiers
+    );
+
+    if (!hasDuplicates) {
+        return structure;
+    }
+
+    structure.namedExports = filterNot(exportSpecifiers, (exportSpecifier) =>
+        isDuplicateExportSpecifier(exportSpecifier, duplicateExportSpecifiers)
+    );
+
+    if (isEmpty(structure.namedExports)) {
+        return;
+    }
+
+    return structure;
 };
 
 const removeExportDeclarations = (
@@ -86,8 +257,12 @@ const removeExportDeclarations = (
     );
 
 export {
+    getInlineExportDeclarations,
+    getEofExportDeclarations,
     getExportDeclarations,
     getExportNames,
+    isEofExportDeclaration,
     mergeExportDeclarationsByFile,
+    moveExportsToEofByFile,
     moveExportsToEof,
 };

--- a/src/utils/exported-declarations-utils.test.ts
+++ b/src/utils/exported-declarations-utils.test.ts
@@ -6,25 +6,20 @@ import {
 
 describe("ExportedDeclarationsUtils", () => {
     describe(asExportedNode.name, () => {
-        it.todo(
-            "should return undefined when node is not exportable",
-            () => {}
-        );
+        it.todo("should return undefined when node is not exportable");
 
         describe(`${VariableStatement.name} and ${VariableDeclaration.name}`, () => {
             it.todo(
-                `should return ${VariableStatement.name} when node is ${VariableDeclaration.name}`,
-                () => {}
+                `should return ${VariableStatement.name} when node is ${VariableDeclaration.name}`
             );
 
             it.todo(
-                `should return undefined when node is ${VariableDeclaration.name} and ${VariableStatement.name} can't be found`,
-                () => {}
+                `should return undefined when node is ${VariableDeclaration.name} and ${VariableStatement.name} can't be found`
             );
         });
     });
 
     describe(getExportedDeclarations.name, () => {
-        it.todo("should return flattened ExportedDeclarations", () => {});
+        it.todo("should return flattened ExportedDeclarations");
     });
 });

--- a/src/utils/exported-declarations-utils.test.ts
+++ b/src/utils/exported-declarations-utils.test.ts
@@ -1,0 +1,30 @@
+import { VariableDeclaration, VariableStatement } from "ts-morph";
+import {
+    asExportedNode,
+    getExportedDeclarations,
+} from "./exported-declarations-utils";
+
+describe("ExportedDeclarationsUtils", () => {
+    describe(asExportedNode.name, () => {
+        it.todo(
+            "should return undefined when node is not exportable",
+            () => {}
+        );
+
+        describe(`${VariableStatement.name} and ${VariableDeclaration.name}`, () => {
+            it.todo(
+                `should return ${VariableStatement.name} when node is ${VariableDeclaration.name}`,
+                () => {}
+            );
+
+            it.todo(
+                `should return undefined when node is ${VariableDeclaration.name} and ${VariableStatement.name} can't be found`,
+                () => {}
+            );
+        });
+    });
+
+    describe(getExportedDeclarations.name, () => {
+        it.todo("should return flattened ExportedDeclarations", () => {});
+    });
+});

--- a/src/utils/exported-declarations-utils.ts
+++ b/src/utils/exported-declarations-utils.ts
@@ -1,0 +1,31 @@
+import { ExportedDeclarations, Node, SourceFile } from "ts-morph";
+import { ExportedNode } from "../types/exported-node";
+
+const asExportedNode = (
+    exportedDeclaration: ExportedDeclarations
+): ExportedNode | undefined => {
+    if (
+        !Node.isExportable(exportedDeclaration) &&
+        !Node.isVariableDeclaration(exportedDeclaration)
+    ) {
+        return;
+    }
+
+    const exportedNode = Node.isVariableDeclaration(exportedDeclaration)
+        ? exportedDeclaration.getVariableStatement()
+        : exportedDeclaration;
+
+    return exportedNode;
+};
+
+const getExportedDeclarations = (file: SourceFile): ExportedDeclarations[] => {
+    const exportMap = file.getExportedDeclarations();
+    const aggregatedExportedDeclarations: ExportedDeclarations[] = [];
+    exportMap.forEach((exportedDeclarations) => {
+        aggregatedExportedDeclarations.push(...exportedDeclarations);
+    });
+
+    return aggregatedExportedDeclarations;
+};
+
+export { asExportedNode, getExportedDeclarations };

--- a/src/utils/exported-node-utils.ts
+++ b/src/utils/exported-node-utils.ts
@@ -22,7 +22,8 @@ const getExportedNodeName = (
 };
 
 const isEofExportedNode = (exportedNode: ExportedNode): boolean => {
-    if (!Node.hasName(exportedNode)) {
+    const name = getExportedNodeName(exportedNode);
+    if (name == null) {
         return false;
     }
 
@@ -30,7 +31,7 @@ const isEofExportedNode = (exportedNode: ExportedNode): boolean => {
     const eofStatements = getEofExportDeclarations(file);
     const exportNames = getExportNames(eofStatements);
 
-    return exportNames.includes(exportedNode.getName());
+    return exportNames.includes(name);
 };
 
 const isInlineExportedNode = (exportedNode: ExportedNode): boolean =>

--- a/src/utils/exported-node-utils.ts
+++ b/src/utils/exported-node-utils.ts
@@ -1,0 +1,60 @@
+import { first } from "lodash";
+import { Node } from "ts-morph";
+import { ExportedNode } from "../types/exported-node";
+import { NamedExportStructure } from "../types/named-export-structure";
+import {
+    getEofExportDeclarations,
+    getExportNames,
+} from "./export-declaration-utils";
+
+const getExportedNodeName = (
+    exportedNode: ExportedNode
+): string | undefined => {
+    if (Node.isVariableStatement(exportedNode)) {
+        return first(exportedNode.getDeclarations())?.getName();
+    }
+
+    if (!Node.hasName(exportedNode)) {
+        return;
+    }
+
+    return exportedNode.getName();
+};
+
+const isEofExportedNode = (exportedNode: ExportedNode): boolean => {
+    if (!Node.hasName(exportedNode)) {
+        return false;
+    }
+
+    const file = exportedNode.getSourceFile();
+    const eofStatements = getEofExportDeclarations(file);
+    const exportNames = getExportNames(eofStatements);
+
+    return exportNames.includes(exportedNode.getName());
+};
+
+const isInlineExportedNode = (exportedNode: ExportedNode): boolean =>
+    !isEofExportedNode(exportedNode);
+
+const toNamedExportStructure = (
+    exportedNode: ExportedNode
+): NamedExportStructure | undefined => {
+    const name = getExportedNodeName(exportedNode);
+    if (name == null) {
+        return;
+    }
+
+    return {
+        name,
+        isType:
+            Node.isTypeAliasDeclaration(exportedNode) ||
+            Node.isInterfaceDeclaration(exportedNode),
+    };
+};
+
+export {
+    getExportedNodeName,
+    isEofExportedNode,
+    isInlineExportedNode,
+    toNamedExportStructure,
+};

--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -1,0 +1,46 @@
+import { isEmpty } from "lodash";
+import { Project, SourceFile } from "ts-morph";
+import { RuleResult } from "../interfaces/rule-result";
+import { Logger } from "./logger";
+
+const safelySafeChangesFromResult = async (
+    result: RuleResult
+): Promise<RuleResult> => {
+    safelySaveChanges(result.file);
+    return result;
+};
+
+const safelySaveChanges = async (fileOrProject: SourceFile | Project) => {
+    if (isSourceFile(fileOrProject) && fileOrProject.isSaved()) {
+        return;
+    }
+
+    const diagnostics = fileOrProject.getPreEmitDiagnostics();
+
+    if (isEmpty(diagnostics)) {
+        await fileOrProject.save();
+        return;
+    }
+
+    const typeName = isSourceFile(fileOrProject)
+        ? fileOrProject.getBaseName()
+        : "project";
+
+    Logger.error(
+        `Found pre-emit diagnostics when attempting to save ${typeName}\n`,
+        getProject(fileOrProject).formatDiagnosticsWithColorAndContext(
+            diagnostics
+        )
+    );
+
+    return;
+};
+
+const getProject = (fileOrProject: SourceFile | Project): Project =>
+    isSourceFile(fileOrProject) ? fileOrProject.getProject() : fileOrProject;
+
+const isSourceFile = (
+    fileOrProject: SourceFile | Project
+): fileOrProject is SourceFile => fileOrProject instanceof SourceFile;
+
+export { safelySafeChangesFromResult, safelySaveChanges };

--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -19,6 +19,10 @@ const safelySaveChanges = async (fileOrProject: SourceFile | Project) => {
 
     if (isEmpty(diagnostics)) {
         await fileOrProject.save();
+        if (isSourceFile(fileOrProject)) {
+            await fileOrProject.refreshFromFileSystem();
+        }
+
         return;
     }
 

--- a/src/utils/import-utils.ts
+++ b/src/utils/import-utils.ts
@@ -1,0 +1,50 @@
+import { compact } from "lodash";
+import { ImportDeclaration, ImportSpecifier, SourceFile } from "ts-morph";
+
+const getDefaultImportDeclarationsForFile = (
+    sourceFile: SourceFile,
+    referencingFiles: SourceFile[]
+): ImportDeclaration[] => {
+    const defaultImports = referencingFiles.map((referencingFile) =>
+        referencingFile
+            .getImportDeclarations()
+            .find(
+                (importDeclaration) =>
+                    importDeclaration.getDefaultImport() != null &&
+                    importDeclaration.getModuleSpecifierSourceFile() ===
+                        sourceFile
+            )
+    );
+
+    return compact(defaultImports);
+};
+
+const replaceDefaultImports = (file: SourceFile, importName: string) => {
+    const referencingSourceFiles = file.getReferencingSourceFiles();
+    const defaultImports = getDefaultImportDeclarationsForFile(
+        file,
+        referencingSourceFiles
+    );
+
+    defaultImports.forEach((importDeclaration) =>
+        replaceDefaultImport(importName, importDeclaration)
+    );
+};
+
+const replaceDefaultImport = (
+    importName: string,
+    importDeclaration: ImportDeclaration
+) => {
+    const existingNamedImports = importDeclaration
+        .getNamedImports()
+        .map((importSpecifier: ImportSpecifier) =>
+            importSpecifier.getStructure()
+        );
+
+    importDeclaration.set({
+        defaultImport: undefined,
+        namedImports: [importName, ...existingNamedImports],
+    });
+};
+
+export { replaceDefaultImports };

--- a/src/utils/internal-codegen/scaffold-new-rule.ts
+++ b/src/utils/internal-codegen/scaffold-new-rule.ts
@@ -41,7 +41,7 @@ const addRuleFunction = (project: Project, name: string) => {
     const file = project.createSourceFile(
         `src/rules/${name}.ts`,
         tags.stripIndent`
-            const ${functionName}: RuleFunction = async (
+            const _${functionName}: RuleFunction = async (
                 file: SourceFile
             ): Promise<RuleResult> => {
                 const originalFileContent = file.getText();
@@ -55,11 +55,13 @@ const addRuleFunction = (project: Project, name: string) => {
                 };
             };
 
-            ${functionName}._name = ${getFullyQualifiedEnumValue(name)};
+            _${functionName}._name = ${getFullyQualifiedEnumValue(name)};
 
             const stub = (): RuleViolation[] => {
                 return [];
             }
+
+            const ${functionName} = withRetry(_${functionName});
         `
     );
 
@@ -80,6 +82,7 @@ const addRuleFunction = (project: Project, name: string) => {
         },
         { namedImports: ["Logger"], moduleSpecifier: "../utils/logger" },
         { namedImports: ["SourceFile"], moduleSpecifier: "ts-morph" },
+        { namedImports: ["withRetry"], moduleSpecifier: "../utils/with-retry" },
     ]);
 
     file.addExportDeclaration({ namedExports: [functionName] });

--- a/src/utils/internal-codegen/scaffold-new-rule.ts
+++ b/src/utils/internal-codegen/scaffold-new-rule.ts
@@ -55,6 +55,8 @@ const addRuleFunction = (project: Project, name: string) => {
                 };
             };
 
+            ${functionName}._name = ${getFullyQualifiedEnumValue(name)};
+
             const stub = (): RuleViolation[] => {
                 return [];
             }

--- a/src/utils/rule-runner.ts
+++ b/src/utils/rule-runner.ts
@@ -4,7 +4,7 @@ import { RuleMap } from "../constants/rule-map";
 import { RuleName } from "../enums/rule-name";
 import { RuleResult } from "../interfaces/rule-result";
 import { Context } from "../models/context";
-import { safelySafeChangesFromResult } from "./file-utils";
+import { safelySafeChangesFromResult } from "./safely-save-changes";
 import { Logger } from "./logger";
 import { printRuleResults } from "./print-rule-results";
 

--- a/src/utils/rule-runner.ts
+++ b/src/utils/rule-runner.ts
@@ -4,6 +4,7 @@ import { RuleMap } from "../constants/rule-map";
 import { RuleName } from "../enums/rule-name";
 import { RuleResult } from "../interfaces/rule-result";
 import { Context } from "../models/context";
+import { safelySafeChangesFromResult } from "./file-utils";
 import { Logger } from "./logger";
 import { printRuleResults } from "./print-rule-results";
 
@@ -30,7 +31,9 @@ const ruleRunner = async (files: SourceFile[]): Promise<RuleResult[]> => {
         flatten(
             rules.map((rule) => {
                 const ruleFunction = RuleMap[rule];
-                return files.map(ruleFunction);
+                return files.map((file) =>
+                    ruleFunction(file).then(safelySafeChangesFromResult)
+                );
             })
         )
     );

--- a/src/utils/rule-runner.ts
+++ b/src/utils/rule-runner.ts
@@ -4,7 +4,6 @@ import { RuleMap } from "../constants/rule-map";
 import { RuleName } from "../enums/rule-name";
 import { RuleResult } from "../interfaces/rule-result";
 import { Context } from "../models/context";
-import { safelySafeChangesFromResult } from "./safely-save-changes";
 import { Logger } from "./logger";
 import { printRuleResults } from "./print-rule-results";
 
@@ -31,9 +30,7 @@ const ruleRunner = async (files: SourceFile[]): Promise<RuleResult[]> => {
         flatten(
             rules.map((rule) => {
                 const ruleFunction = RuleMap[rule];
-                return files.map((file) =>
-                    ruleFunction(file).then(safelySafeChangesFromResult)
-                );
+                return files.map(ruleFunction);
             })
         )
     );

--- a/src/utils/safely-save-changes.ts
+++ b/src/utils/safely-save-changes.ts
@@ -6,7 +6,7 @@ import { Logger } from "./logger";
 const safelySafeChangesFromResult = async (
     result: RuleResult
 ): Promise<RuleResult> => {
-    safelySaveChanges(result.file);
+    await safelySaveChanges(result.file);
     return result;
 };
 
@@ -19,10 +19,6 @@ const safelySaveChanges = async (fileOrProject: SourceFile | Project) => {
 
     if (isEmpty(diagnostics)) {
         await fileOrProject.save();
-        if (isSourceFile(fileOrProject)) {
-            await fileOrProject.refreshFromFileSystem();
-        }
-
         return;
     }
 

--- a/src/utils/with-retry.ts
+++ b/src/utils/with-retry.ts
@@ -9,7 +9,7 @@ import chalk from "chalk";
  */
 const withRetry = (rule: RuleFunction) =>
     (async (file: SourceFile) => {
-        const ruleName = chalk.magenta(rule.__name);
+        const ruleName = chalk.magenta(rule._name);
         const fileName = chalk.bold(file.getBaseName());
         for (let i = 0; i < 3; i++) {
             try {


### PR DESCRIPTION
Resolves #21
Resolves #41

-Adds a util that checks for pre-emit diagnostics before saving and bails if any are found. 

Will be adding documentation in an another pass - this turned into quite the beast of a feature/rule to implement due to all of the edge cases I found, and somewhat duplicates some functionality in the `NamedExportsOnly` 