### PR TITLE
chore: drop personal eslint-config package and vendorize config instead

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,5 @@
 {
-    "extends": [
-        "plugin:@typescript-eslint/recommended",
-        "@brandongregoryscott/eslint-config",
-        "@brandongregoryscott/eslint-config/typescript"
-    ],
+    "extends": ["plugin:@typescript-eslint/recommended"],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
         "ecmaFeatures": {
@@ -18,6 +14,54 @@
         "@typescript-eslint"
     ],
     "rules": {
-        "@typescript-eslint/sort-type-union-intersection-members": "off"
+        "@typescript-eslint/consistent-type-definitions": "error",
+        "@typescript-eslint/consistent-type-exports": "error",
+        "@typescript-eslint/consistent-type-imports": "error",
+        "@typescript-eslint/padding-line-between-statements": [
+            "error",
+            {
+                "blankLine": "always",
+                "next": "export",
+                "prev": "*"
+            },
+            {
+                "blankLine": "never",
+                "next": "export",
+                "prev": "export"
+            },
+            {
+                "blankLine": "always",
+                "next": "*",
+                "prev": "import"
+            },
+            {
+                "blankLine": "never",
+                "next": "import",
+                "prev": "import"
+            }
+        ],
+        "@typescript-eslint/strict-boolean-expressions": "error",
+        "collation/group-exports": "error",
+        "collation/no-default-export": "error",
+        "collation/no-inline-export": "error",
+        "collation/sort-exports": "error",
+        "curly": "error",
+        "eqeqeq": [
+            "error",
+            "always",
+            {
+                "null": "ignore"
+            }
+        ],
+        "import/no-duplicates": "error",
+        "no-console": "error",
+        "typescript-sort-keys/interface": [
+            "error",
+            "asc",
+            {
+                "caseSensitive": false
+            }
+        ],
+        "typescript-sort-keys/string-enum": "error"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
                 "minimatch": "9.0.0"
             },
             "devDependencies": {
-                "@brandongregoryscott/eslint-config": "1.0.1",
                 "@types/common-tags": "1.8.1",
                 "@types/jest": "27.5.1",
                 "@types/lodash": "4.14.182",
@@ -556,24 +555,6 @@
             "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
-        },
-        "node_modules/@brandongregoryscott/eslint-config": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@brandongregoryscott/eslint-config/-/eslint-config-1.0.1.tgz",
-            "integrity": "sha512-f2hlhrATU0tqdGBYIzdq6ZkULtBO8M7bQB2WeJPekvjuscmtKa66KddPcBqBqZ28cvlAe9GHlQ+EAER1zRhEqg==",
-            "dev": true,
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@typescript-eslint/eslint-plugin": ">=5",
-                "@typescript-eslint/parser": ">=5",
-                "@typescript-eslint/utils": ">=5",
-                "eslint": ">=6",
-                "eslint-plugin-collation": "^1.1.2",
-                "eslint-plugin-import": "^2.27.5",
-                "eslint-plugin-typescript-sort-keys": "^2.1.0"
-            }
         },
         "node_modules/@colors/colors": {
             "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     },
     "description": "ESLint plugin for making your code easier to read",
     "devDependencies": {
-        "@brandongregoryscott/eslint-config": "1.0.1",
         "@types/common-tags": "1.8.1",
         "@types/jest": "27.5.1",
         "@types/lodash": "4.14.182",

--- a/src/utils/rule-utils.ts
+++ b/src/utils/rule-utils.ts
@@ -12,7 +12,8 @@ const tryRule = <TMessageIds extends string, TOptions extends unknown[]>(
         fn();
     } catch (error) {
         const prefix = `collation/${context.id}`;
-        const filename = context.getFilename();
+        const { filename } = context;
+        // eslint-disable-next-line no-console -- We don't want to silently swallow this error
         console.error(`${prefix}: Error while linting ${filename}`, error);
     }
 };


### PR DESCRIPTION
I've found the maintenance associated with keeping ESLint + plugin versions in sync with multiple projects that depend on https://github.com/brandongregoryscott/eslint-config is not worth it. Vendorizing the config in any projects that use it directly and using the repo as a reference for setting up new projects instead.